### PR TITLE
Add support for request filtering

### DIFF
--- a/munit-cats-effect-pact/src/test/scala/pact4s/munit/RequestResponsePactVerifierMUnitSuite.scala
+++ b/munit-cats-effect-pact/src/test/scala/pact4s/munit/RequestResponsePactVerifierMUnitSuite.scala
@@ -3,7 +3,7 @@ package pact4s.munit
 import munit.CatsEffectSuite
 import pact4s.{MockProviderServer, ProviderInfoBuilder}
 
-class ResponseResponsePactVerifierMUnitSuite extends CatsEffectSuite with PactVerifier {
+class RequestResponsePactVerifierMUnitSuite extends CatsEffectSuite with PactVerifier {
   val mock = new MockProviderServer(2345)
 
   override val provider: ProviderInfoBuilder = mock.fileSourceProviderInfo(

--- a/scripts/Pact4sConsumer-Pact4sProvider.json
+++ b/scripts/Pact4sConsumer-Pact4sProvider.json
@@ -50,6 +50,16 @@
         },
         "status": 200
       }
+    },
+    {
+      "description": "a request to an authenticated endpoint",
+      "request": {
+        "method": "GET",
+        "path": "/authorized"
+      },
+      "response": {
+        "status": 200
+      }
     }
   ],
   "metadata": {


### PR DESCRIPTION
This will allow providers to modify request headers before requests are issued against the provider application. One common use-case for this is allowing the provider application to inject authorization headers into the requests.

@jbwheatley feel free to modify this as you see fit. Locally I seem to be having some issues getting the `MUnit` tests to pass, but everything else seems to work fine.