### PR TITLE
Don't fail the build if verification fails against a pending pact.

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,10 @@ This will cause a request to be sent to the setup url prior to verification of e
 
 ---
 
-### Notes on Contributing
+## Contributing
 
 We use [sbt-projectmatrix](https://github.com/sbt/sbt-projectmatrix) to easily reuse code across the different scala and jdk versions. Using `sbt test` with `projectmatrix` doesn't seem to respect turning off parallel test execution, which we need because the tests use locking resources. So instead, in order to run the tests use `sbt commitCheck` to run the tests in series. This is quite slow, so `sbt quickCommitCheck` will only run the tests on scala 2.13. Thanks to [sbt-commandmatrix](https://github.com/indoorvivants/sbt-commandmatrix) for enabling this. 
+
+### IntelliJ
+
+When importing the project into the [IntelliJ IDE](https://www.jetbrains.com/idea/), the Scala 2.12.x and Java 8 projects and dependency classpaths will be excluded to prevent IntelliJ from complaining about duplicate classes on the classpath. This means when developing and running tests inside the IDE, Scala 2.13.x and Java 11 will be used.

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val javaVersionDimension =
 inThisBuild(
   List(
     organization := "io.github.jbwheatley",
-    homepage := Some(url("https://github.com/jbwheatley/pact4s")),
+    homepage     := Some(url("https://github.com/jbwheatley/pact4s")),
     developers := List(
       Developer(
         "jbwheatley",
@@ -28,7 +28,7 @@ inThisBuild(
         url("https://github.com/jbwheatley")
       )
     ),
-    licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+    licenses     := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     scalaVersion := scala213,
     commands ++= CrossCommand.single(
       "test",
@@ -45,6 +45,9 @@ inThisBuild(
 publish / skip := true // don't publish the root project
 
 val commonSettings = Seq(
+  // When using IntelliJ, don't import projects for Scala 2.12.x or Java 8. This prevents classpath conflicts.
+  // See: https://github.com/sbt/sbt-projectmatrix/issues/25
+  ideSkipProject.withRank(KeyRanks.Invisible) := scalaVersion.value.startsWith("2.12.") || name.value.contains("java8"),
   resolvers ++= Seq(
     Resolver.mavenLocal,
     Resolver.url("typesafe", url("https://repo.typesafe.com/typesafe/ivy-releases/"))(Resolver.ivyStylePatterns)
@@ -89,6 +92,7 @@ lazy val shared =
 lazy val circe = (projectMatrix in file("circe"))
   .customRow(scalaVersions = scala2Versions, axisValues = Seq(VirtualAxis.jvm, PactJvmAxis.java11), identity(_))
   .customRow(scalaVersions = scala2Versions, axisValues = Seq(VirtualAxis.jvm, PactJvmAxis.java8), identity(_))
+  .settings(commonSettings)
   .settings(
     name := moduleName("pact4s-circe", virtualAxes.value),
     libraryDependencies ++= Dependencies.circe,
@@ -114,6 +118,7 @@ lazy val munit =
   (projectMatrix in file("munit-cats-effect-pact"))
     .customRow(scalaVersions = scala2Versions, axisValues = Seq(VirtualAxis.jvm, PactJvmAxis.java11), identity(_))
     .customRow(scalaVersions = scala2Versions, axisValues = Seq(VirtualAxis.jvm, PactJvmAxis.java8), identity(_))
+    .settings(commonSettings)
     .settings(
       name := moduleName("pact4s-munit-cats-effect", virtualAxes.value),
       libraryDependencies ++= Dependencies.munit,
@@ -126,6 +131,7 @@ lazy val scalaTest =
   (projectMatrix in file("scalatest-pact"))
     .customRow(scalaVersions = scala2Versions, axisValues = Seq(VirtualAxis.jvm, PactJvmAxis.java11), identity(_))
     .customRow(scalaVersions = scala2Versions, axisValues = Seq(VirtualAxis.jvm, PactJvmAxis.java8), identity(_))
+    .settings(commonSettings)
     .settings(
       name := moduleName("pact4s-scalatest", virtualAxes.value),
       libraryDependencies ++= Dependencies.scalatest
@@ -136,6 +142,7 @@ lazy val scalaTest =
 lazy val weaver = (projectMatrix in file("weaver-pact"))
   .customRow(scalaVersions = scala2Versions, axisValues = Seq(VirtualAxis.jvm, PactJvmAxis.java11), identity(_))
   .customRow(scalaVersions = scala2Versions, axisValues = Seq(VirtualAxis.jvm, PactJvmAxis.java8), identity(_))
+  .settings(commonSettings)
   .settings(
     name := moduleName("pact4s-weaver", virtualAxes.value),
     libraryDependencies ++= Dependencies.weaver,

--- a/munit-cats-effect-pact/src/main/scala/pact4s/munit/PactVerifier.scala
+++ b/munit-cats-effect-pact/src/main/scala/pact4s/munit/PactVerifier.scala
@@ -21,7 +21,8 @@ import pact4s.PactVerifyResources
 import sourcecode.{File, FileName, Line}
 
 trait PactVerifier extends Assertions with PactVerifyResources {
-  override private[pact4s] def skip(message: String)(implicit fileName: FileName, file: File, line: Line): Unit = ()
+  override private[pact4s] def skip(message: String)(implicit fileName: FileName, file: File, line: Line): Unit =
+    assume(cond = false, message)
   override private[pact4s] def failure(message: String)(implicit fileName: FileName, file: File, line: Line): Nothing =
     fail(message)(new Location(file.value, line.value))
 }

--- a/munit-cats-effect-pact/src/main/scala/pact4s/munit/PactVerifier.scala
+++ b/munit-cats-effect-pact/src/main/scala/pact4s/munit/PactVerifier.scala
@@ -21,6 +21,7 @@ import pact4s.PactVerifyResources
 import sourcecode.{File, FileName, Line}
 
 trait PactVerifier extends Assertions with PactVerifyResources {
+  override private[pact4s] def skip(message: String)(implicit fileName: FileName, file: File, line: Line): Unit = ()
   override private[pact4s] def failure(message: String)(implicit fileName: FileName, file: File, line: Line): Nothing =
     fail(message)(new Location(file.value, line.value))
 }

--- a/munit-cats-effect-pact/src/test/scala/pact4s/munit/PendingPactVerificationTestSuite.scala
+++ b/munit-cats-effect-pact/src/test/scala/pact4s/munit/PendingPactVerificationTestSuite.scala
@@ -1,0 +1,8 @@
+package pact4s.munit
+
+import munit.CatsEffectSuite
+import pact4s.PendingPactVerificationFixture
+
+class PendingPactVerificationTestSuite extends CatsEffectSuite with PactVerifier with PendingPactVerificationFixture {
+  test("pending pact failure should be skipped")(verifyPacts())
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,6 +1,7 @@
 import sbt._
 
 object Dependencies {
+  val mockitoScala     = "1.16.39"
   val pactJvmJava11    = "4.2.11"
   val pactJvmJava8     = "4.1.26"
   val http4s           = "1.0.0-M25"
@@ -17,13 +18,14 @@ object Dependencies {
     Seq(
       "au.com.dius.pact"        % "consumer"                % pactJvmVersion,
       "au.com.dius.pact"        % "provider"                % pactJvmVersion,
-      "org.http4s"             %% "http4s-ember-client"     % http4s  % Test,
-      "org.http4s"             %% "http4s-dsl"              % http4s  % Test,
-      "org.http4s"             %% "http4s-ember-server"     % http4s  % Test,
-      "org.http4s"             %% "http4s-circe"            % http4s  % Test,
-      "io.circe"               %% "circe-core"              % _circe  % Test,
+      "org.http4s"             %% "http4s-ember-client"     % http4s       % Test,
+      "org.http4s"             %% "http4s-dsl"              % http4s       % Test,
+      "org.http4s"             %% "http4s-ember-server"     % http4s       % Test,
+      "org.http4s"             %% "http4s-circe"            % http4s       % Test,
+      "io.circe"               %% "circe-core"              % _circe       % Test,
+      "org.mockito"            %% "mockito-scala"           % mockitoScala % Test,
       "org.log4s"              %% "log4s"                   % log4s,
-      "ch.qos.logback"          % "logback-classic"         % logback % Runtime,
+      "ch.qos.logback"          % "logback-classic"         % logback      % Runtime,
       "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompat,
       "com.lihaoyi"            %% "sourcecode"              % sourcecode
     )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
 addSbtPlugin("com.geirsson"                      % "sbt-ci-release"    % "1.5.7")
 addSbtPlugin("de.heikoseeberger"                 % "sbt-header"        % "5.6.0")
+addSbtPlugin("org.jetbrains.scala"               % "sbt-ide-settings"  % "1.1.1")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"      % "2.4.3")
 addSbtPlugin("io.github.davidgregory084"         % "sbt-tpolecat"      % "0.1.20")
 addSbtPlugin("com.eed3si9n"                      % "sbt-projectmatrix" % "0.8.0")

--- a/scalatest-pact/src/main/scala/pact4s/scalatest/PactVerifier.scala
+++ b/scalatest-pact/src/main/scala/pact4s/scalatest/PactVerifier.scala
@@ -22,6 +22,8 @@ import pact4s.PactVerifyResources
 import sourcecode.{File, FileName, Line}
 
 trait PactVerifier extends Assertions with PactVerifyResources {
+  override private[pact4s] def skip(message: String)(implicit fileName: FileName, file: File, line: Line): Unit =
+    cancel(message)(Position(fileName.value, file.value, line.value))
   override private[pact4s] def failure(message: String)(implicit fileName: FileName, file: File, line: Line): Nothing =
     fail(message)(Position(fileName.value, file.value, line.value))
 }

--- a/scalatest-pact/src/test/scala/pact4s/scalatest/PendingPactVerificationTestSuite.scala
+++ b/scalatest-pact/src/test/scala/pact4s/scalatest/PendingPactVerificationTestSuite.scala
@@ -1,0 +1,7 @@
+package pact4s.scalatest
+import org.scalatest.flatspec.AnyFlatSpec
+import pact4s.PendingPactVerificationFixture
+
+class PendingPactVerificationTestSuite extends AnyFlatSpec with PactVerifier with PendingPactVerificationFixture {
+  "pending pact failure" should "be skipped" in verifyPacts()
+}

--- a/shared/src/main/scala/pact4s/PactVerifyResources.scala
+++ b/shared/src/main/scala/pact4s/PactVerifyResources.scala
@@ -37,18 +37,20 @@ trait PactVerifyResources {
 
   private[pact4s] def verifySingleConsumer(
       consumer: IConsumerInfo
-  )(implicit fileName: FileName, file: File, line: Line): Unit =
-    verifier.runVerificationForConsumer(new java.util.HashMap[String, Object](), providerInfo, consumer) match {
-      case failed: VerificationResult.Failed =>
-        verifier.displayFailures(List(failed).asJava)
-        // Don't fail the build if the pact is pending.
-        val pending = failed.getPending
-        val message = s"Verification failed${if (pending) " [SKIPPED]" else ""}:\n ${failed.toString}"
-        val action  = if (pending) skip _ else failure _
-        action(message)
-      case _: VerificationResult.Ok => ()
-      case _                        => ???
-    }
+  )(implicit fileName: FileName, file: File, line: Line): Unit = runVerification(consumer) match {
+    case failed: VerificationResult.Failed =>
+      verifier.displayFailures(List(failed).asJava)
+      // Don't fail the build if the pact is pending.
+      val pending = failed.getPending
+      val message = s"""Verification failed${if (pending) " [PENDING]" else ""}: "${failed.getDescription}""""
+      val action  = if (pending) skip _ else failure _
+      action(message)
+    case _: VerificationResult.Ok => ()
+    case _                        => ???
+  }
+
+  private[pact4s] def runVerification(consumer: IConsumerInfo): VerificationResult =
+    verifier.runVerificationForConsumer(new java.util.HashMap[String, Object](), providerInfo, consumer, null)
 
   /** @param publishVerificationResults
     *   if set, results of verification will be published to the pact broker, along with version and tags

--- a/shared/src/test/scala/pact4s/PendingPactVerificationFixture.scala
+++ b/shared/src/test/scala/pact4s/PendingPactVerificationFixture.scala
@@ -1,0 +1,41 @@
+package pact4s
+
+import au.com.dius.pact.provider.{
+  IConsumerInfo,
+  ProviderInfo,
+  ProviderVerifier,
+  VerificationFailureType,
+  VerificationResult
+}
+import org.mockito.MockitoSugar
+
+import java.util
+import scala.annotation.nowarn
+import scala.jdk.CollectionConverters._
+
+/** Provides a test fixture for PactVerifyResources which produces a consumer pact failure that is pending.
+  * @see
+  *   https://github.com/jbwheatley/pact4s/pull/52
+  */
+trait PendingPactVerificationFixture extends MockitoSugar { this: PactVerifyResources =>
+  override private[pact4s] val verifier = mock[ProviderVerifier]
+  override private[pact4s] lazy val providerInfo = {
+    val providerInfo = mock[ProviderInfo]
+    val consumer     = mock[IConsumerInfo]
+    when(providerInfo.getConsumers).thenReturn(List(consumer).asJava)
+    providerInfo
+  }
+
+  lazy val provider: ProviderInfoBuilder = ProviderInfoBuilder("", mock[PactSource])
+
+  @nowarn("cat=unused")
+  override private[pact4s] def runVerification(consumer: IConsumerInfo): VerificationResult = {
+    val description: String             = "description"
+    val verificationDescription: String = "verificationDescription"
+    val failures: util.Map[String, util.List[VerificationFailureType]] =
+      Map[String, util.List[VerificationFailureType]]().asJava
+    val pending: Boolean                             = true
+    val results: util.List[util.Map[String, AnyRef]] = List[util.Map[String, AnyRef]]().asJava
+    new VerificationResult.Failed(description, verificationDescription, failures, pending, results)
+  }
+}

--- a/weaver-pact/src/main/scala/pact4s/weaver/PactVerifier.scala
+++ b/weaver-pact/src/main/scala/pact4s/weaver/PactVerifier.scala
@@ -19,9 +19,11 @@ package pact4s.weaver
 import cats.data.NonEmptyList
 import pact4s.PactVerifyResources
 import sourcecode.{File, FileName, Line}
-import weaver.{AssertionException, SourceLocation}
+import weaver.{AssertionException, CanceledException, SourceLocation}
 
 trait PactVerifier extends PactVerifyResources {
+  override private[pact4s] def skip(message: String)(implicit fileName: FileName, file: File, line: Line): Unit =
+    throw new CanceledException(Some(message), SourceLocation(file.value, fileName.value, line.value))
   override private[pact4s] def failure(message: String)(implicit fileName: FileName, file: File, line: Line): Nothing =
     throw AssertionException(message, NonEmptyList.of(SourceLocation(file.value, fileName.value, line.value)))
 }

--- a/weaver-pact/src/test/scala/pact4s/weaver/PendingPactVerificationTestSuite.scala
+++ b/weaver-pact/src/test/scala/pact4s/weaver/PendingPactVerificationTestSuite.scala
@@ -1,0 +1,8 @@
+package pact4s.weaver
+
+import pact4s.PendingPactVerificationFixture
+import weaver.SimpleIOSuite
+
+object PendingPactVerificationTestSuite extends SimpleIOSuite with PactVerifier with PendingPactVerificationFixture {
+  pureTest("pending pact failure should be skipped")(succeed(verifyPacts()))
+}


### PR DESCRIPTION
Fixes #51

This also includes the [sbt-ide-settings](https://github.com/JetBrains/sbt-ide-settings) plugin and configures the project so that when it is imported into the IntelliJ IDE it will exclude Scala 2.12 and Java 8 dependencies and projects. This prevents classpath conflicts (e.g. the same classes existing in 4 different contexts) and allows for a normal development experience (including the ability to run and debug tests from the IDE).