### PR TITLE
enforce providerTags to be set when pending pact enabled

### DIFF
--- a/munit-cats-effect-pact/src/test/scala/pact4s/munit/RequestResponsePactForgerMUnitSuite.scala
+++ b/munit-cats-effect-pact/src/test/scala/pact4s/munit/RequestResponsePactForgerMUnitSuite.scala
@@ -21,8 +21,8 @@ class RequestResponsePactForgerMUnitSuite extends RequestResponsePactForger {
 
   val pact: RequestResponsePact =
     ConsumerPactBuilder
-      .consumer("Consumer")
-      .hasPactWith("Provider")
+      .consumer("Pact4sConsumer")
+      .hasPactWith("Pact4sProvider")
       .uponReceiving("a request to say Hello")
       .path("/hello")
       .method("POST")

--- a/scalatest-pact/src/test/scala/pact4s/scalatest/RequestResponsePactForgerScalaTestSuite.scala
+++ b/scalatest-pact/src/test/scala/pact4s/scalatest/RequestResponsePactForgerScalaTestSuite.scala
@@ -23,8 +23,8 @@ class RequestResponsePactForgerScalaTestSuite extends AnyFlatSpec with Matchers 
 
   val pact: RequestResponsePact =
     ConsumerPactBuilder
-      .consumer("Consumer")
-      .hasPactWith("Provider")
+      .consumer("Pact4sConsumer")
+      .hasPactWith("Pact4sProvider")
       .uponReceiving("a request to say Hello")
       .path("/hello")
       .method("POST")

--- a/scripts/Pact4sConsumer-Pact4sProvider.json
+++ b/scripts/Pact4sConsumer-Pact4sProvider.json
@@ -50,21 +50,11 @@
         },
         "status": 200
       }
-    },
-    {
-      "description": "a request to an authenticated endpoint",
-      "request": {
-        "method": "GET",
-        "path": "/authorized"
-      },
-      "response": {
-        "status": 200
-      }
     }
   ],
   "metadata": {
     "pact-jvm": {
-      "version": "4.2.8"
+      "version": "4.2.11"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/scripts/Pact4sMessageConsumer-Pact4sMessageProvider.json
+++ b/scripts/Pact4sMessageConsumer-Pact4sMessageProvider.json
@@ -51,7 +51,7 @@
   ],
   "metadata": {
     "pact-jvm": {
-      "version": "4.2.8"
+      "version": "4.2.11"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/shared/src/main/scala/pact4s/ProviderInfoBuilder.scala
+++ b/shared/src/main/scala/pact4s/ProviderInfoBuilder.scala
@@ -18,6 +18,7 @@ package pact4s
 
 import au.com.dius.pact.core.model.{FileSource => PactJVMFileSource}
 import au.com.dius.pact.core.pactbroker.{ConsumerVersionSelector => PactJVMSelector}
+import au.com.dius.pact.core.support.Auth
 import au.com.dius.pact.provider.{PactVerification, ProviderInfo}
 import org.apache.http.HttpRequest
 import org.apache.http.message.BasicHeader
@@ -130,8 +131,8 @@ final case class ProviderInfoBuilder(
         options.put("enablePending", enablePending)
         options.put("providerTags", providerTags.toList.asJava)
         auth.foreach {
-          case TokenAuth(token)      => options.put("authentication", List("bearer", token).asJava)
-          case BasicAuth(user, pass) => options.put("authentication", List("basic", user, pass).asJava)
+          case TokenAuth(token)      => options.put("authentication", new Auth.BearerAuthentication(token))
+          case BasicAuth(user, pass) => options.put("authentication", new Auth.BasicAuthentication(user, pass))
         }
         includeWipPactsSince.foreach(since => options.put("includeWipPactsSince", instantToDateString(since)))
         providerInfo.hasPactsFromPactBrokerWithSelectors(options, brokerUrl, selectors.map(_.toPactJVMSelector).asJava)

--- a/shared/src/test/scala/pact4s/MockProviderServer.scala
+++ b/shared/src/test/scala/pact4s/MockProviderServer.scala
@@ -14,6 +14,7 @@ import org.http4s.headers.`WWW-Authenticate`
 import org.http4s.implicits.http4sKleisliResponseSyntaxOptionT
 import org.http4s.server.Server
 import pact4s.Authentication.BasicAuth
+import pact4s.PactSource.PactBrokerWithSelectors.ProviderTags
 import pact4s.PactSource.{FileSource, PactBrokerWithSelectors}
 
 import java.io.File
@@ -100,7 +101,7 @@ class MockProviderServer(port: Int) {
       pactSource = PactBrokerWithSelectors(
         brokerUrl = "https://test.pact.dius.com.au"
       ).withAuth(BasicAuth("dXfltyFMgNOFZAxr8io9wJ37iUpY42M", "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"))
-        .withPendingPacts(enabled = true)
+        .withPendingPactsEnabled(ProviderTags.one("SNAPSHOT"))
         .withSelectors(ConsumerVersionSelector())
     ).withPort(port)
       .withOptionalVerificationSettings(verificationSettings)

--- a/weaver-pact/src/test/scala/pact4s/weaver/RequestResponsePactForgerWeaverSuite.scala
+++ b/weaver-pact/src/test/scala/pact4s/weaver/RequestResponsePactForgerWeaverSuite.scala
@@ -22,8 +22,8 @@ object RequestResponsePactForgerWeaverSuite extends IOSuite with RequestResponse
 
   val pact: RequestResponsePact =
     ConsumerPactBuilder
-      .consumer("Consumer")
-      .hasPactWith("Provider")
+      .consumer("Pact4sConsumer")
+      .hasPactWith("Pact4sProvider")
       .uponReceiving("a request to say Hello")
       .path("/hello")
       .method("POST")


### PR DESCRIPTION
If pending pacts are enabled, but no provider tags are set, pact-jvm throws an exception. So in this PR change the API of `PactBrokerWithSelectors` to disallow the setting of one without the other. 

Also, in 4.2.10 and 4.1.25 of pact-jvm, ProviderInfo options were broken out into their own class (so they don't have to be passed as a Map[String, Any]. We use this instead when building `ProviderInfo` from our `ProviderInfoBuilder`. 

