### PR TITLE
PactBrokerWithSelectors ergonomic improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ inThisBuild(
     scalaVersion := scala213,
     commands ++= CrossCommand.single(
       "test",
-      matrices = Seq(circe, munit, scalaTest, weaver),
+      matrices = Seq(shared, circe, munit, scalaTest, weaver),
       dimensions = Seq(
         javaVersionDimension,
         Dimension.scala("2.13"),
@@ -69,6 +69,7 @@ lazy val shared =
     .settings(commonSettings)
     .settings(
       name := moduleName("shared", virtualAxes.value),
+      testFrameworks += new TestFramework("munit.Framework"),
       libraryDependencies ++= {
         val version = virtualAxes.value.collectFirst { case c: PactJvmAxis => c.version }.get
         Dependencies.shared(version)

--- a/munit-cats-effect-pact/src/test/scala/pact4s/munit/MessagePactVerifierBrokerMUnitSuite.scala
+++ b/munit-cats-effect-pact/src/test/scala/pact4s/munit/MessagePactVerifierBrokerMUnitSuite.scala
@@ -13,8 +13,7 @@ class MessagePactVerifierBrokerMUnitSuite extends CatsEffectSuite with MessagePa
   verifyPacts(
     publishVerificationResults = Some(
       PublishVerificationResults(
-        providerVersion = "SNAPSHOT",
-        providerTags = Nil
+        providerVersion = "SNAPSHOT"
       )
     )
   )

--- a/munit-cats-effect-pact/src/test/scala/pact4s/munit/RequestResponsePactVerifierBrokerMUnitSuite.scala
+++ b/munit-cats-effect-pact/src/test/scala/pact4s/munit/RequestResponsePactVerifierBrokerMUnitSuite.scala
@@ -18,8 +18,7 @@ class RequestResponsePactVerifierBrokerMUnitSuite extends CatsEffectSuite with P
     verifyPacts(
       publishVerificationResults = Some(
         PublishVerificationResults(
-          providerVersion = "SNAPSHOT",
-          providerTags = Nil
+          providerVersion = "SNAPSHOT"
         )
       )
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,16 +18,17 @@ object Dependencies {
     Seq(
       "au.com.dius.pact"        % "consumer"                % pactJvmVersion,
       "au.com.dius.pact"        % "provider"                % pactJvmVersion,
+      "org.log4s"              %% "log4s"                   % log4s,
+      "ch.qos.logback"          % "logback-classic"         % logback      % Runtime,
+      "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompat,
+      "com.lihaoyi"            %% "sourcecode"              % sourcecode,
       "org.http4s"             %% "http4s-ember-client"     % http4s       % Test,
       "org.http4s"             %% "http4s-dsl"              % http4s       % Test,
       "org.http4s"             %% "http4s-ember-server"     % http4s       % Test,
       "org.http4s"             %% "http4s-circe"            % http4s       % Test,
       "io.circe"               %% "circe-core"              % _circe       % Test,
       "org.mockito"            %% "mockito-scala"           % mockitoScala % Test,
-      "org.log4s"              %% "log4s"                   % log4s,
-      "ch.qos.logback"          % "logback-classic"         % logback      % Runtime,
-      "org.scala-lang.modules" %% "scala-collection-compat" % collectionCompat,
-      "com.lihaoyi"            %% "sourcecode"              % sourcecode
+      "org.typelevel"          %% "munit-cats-effect-3"     % _munit       % Test
     )
 
   val munit: Seq[ModuleID] = Seq(

--- a/scalatest-pact/src/test/scala/pact4s/scalatest/MessagePactVerifierBrokerScalaTestSuite.scala
+++ b/scalatest-pact/src/test/scala/pact4s/scalatest/MessagePactVerifierBrokerScalaTestSuite.scala
@@ -14,8 +14,7 @@ class MessagePactVerifierBrokerScalaTestSuite extends AnyFlatSpec with MessagePa
     verifyPacts(
       publishVerificationResults = Some(
         PublishVerificationResults(
-          providerVersion = "SNAPSHOT",
-          providerTags = Nil
+          providerVersion = "SNAPSHOT"
         )
       )
     )

--- a/scalatest-pact/src/test/scala/pact4s/scalatest/RequestResponsePactVerifierBrokerScalaTestSuite.scala
+++ b/scalatest-pact/src/test/scala/pact4s/scalatest/RequestResponsePactVerifierBrokerScalaTestSuite.scala
@@ -24,8 +24,7 @@ class RequestResponsePactVerifierBrokerScalaTestSuite extends AnyFlatSpec with P
     verifyPacts(
       publishVerificationResults = Some(
         PublishVerificationResults(
-          providerVersion = "SNAPSHOT",
-          providerTags = Nil
+          providerVersion = "SNAPSHOT"
         )
       )
     )

--- a/shared/src/main/scala/pact4s/PactVerifyResources.scala
+++ b/shared/src/main/scala/pact4s/PactVerifyResources.scala
@@ -103,6 +103,12 @@ final case class PublishVerificationResults(
     providerTags: List[String]
 )
 
+object PublishVerificationResults {
+  def apply(providerVersion: String): PublishVerificationResults = PublishVerificationResults(providerVersion, Nil)
+  def apply(providerVersion: String, providerTags: ProviderTags): PublishVerificationResults =
+    PublishVerificationResults(providerVersion, providerTags.toList)
+}
+
 private[pact4s] final class PactVerifierPropertyResolver(properties: Map[String, String]) {
   def getProperty(name: String): Option[String] = properties.get(name).orElse(Option(System.getProperty(name)))
 }

--- a/shared/src/main/scala/pact4s/PactVerifyResources.scala
+++ b/shared/src/main/scala/pact4s/PactVerifyResources.scala
@@ -88,7 +88,9 @@ trait PactVerifyResources {
     verifier.setProjectGetProperty(p => propertyResolver.getProperty(p).orNull)
     verifier.setProjectHasProperty(name => propertyResolver.getProperty(name).isDefined)
     verifier.setProviderVersion(() => publishVerificationResults.map(_.providerVersion).getOrElse(""))
-    verifier.setProviderTags(() => publishVerificationResults.flatMap(_.providerTags.map(_.toList)).getOrElse(Nil).asJava)
+    verifier.setProviderTags(() =>
+      publishVerificationResults.flatMap(_.providerTags.map(_.toList)).getOrElse(Nil).asJava
+    )
 
     providerInfo.getConsumers.forEach(verifySingleConsumer(_))
     val failedMessages  = failures.toList

--- a/shared/src/main/scala/pact4s/PactVerifyResources.scala
+++ b/shared/src/main/scala/pact4s/PactVerifyResources.scala
@@ -88,7 +88,7 @@ trait PactVerifyResources {
     verifier.setProjectGetProperty(p => propertyResolver.getProperty(p).orNull)
     verifier.setProjectHasProperty(name => propertyResolver.getProperty(name).isDefined)
     verifier.setProviderVersion(() => publishVerificationResults.map(_.providerVersion).getOrElse(""))
-    verifier.setProviderTags(() => publishVerificationResults.map(_.providerTags).getOrElse(Nil).asJava)
+    verifier.setProviderTags(() => publishVerificationResults.flatMap(_.providerTags.map(_.toList)).getOrElse(Nil).asJava)
 
     providerInfo.getConsumers.forEach(verifySingleConsumer(_))
     val failedMessages  = failures.toList
@@ -100,13 +100,18 @@ trait PactVerifyResources {
 
 final case class PublishVerificationResults(
     providerVersion: String,
-    providerTags: List[String]
+    providerTags: Option[ProviderTags]
 )
 
 object PublishVerificationResults {
-  def apply(providerVersion: String): PublishVerificationResults = PublishVerificationResults(providerVersion, Nil)
+  @deprecated("use ProviderTags(..) or ProviderTags.fromList(..) rather than List[String]", "0.0.19")
+  def apply(providerVersion: String, providerTags: List[String]): PublishVerificationResults =
+    PublishVerificationResults(providerVersion, ProviderTags.fromList(providerTags))
+
+  def apply(providerVersion: String): PublishVerificationResults = PublishVerificationResults(providerVersion, None)
+
   def apply(providerVersion: String, providerTags: ProviderTags): PublishVerificationResults =
-    PublishVerificationResults(providerVersion, providerTags.toList)
+    PublishVerificationResults(providerVersion, Some(providerTags))
 }
 
 private[pact4s] final class PactVerifierPropertyResolver(properties: Map[String, String]) {

--- a/shared/src/main/scala/pact4s/ProviderInfoBuilder.scala
+++ b/shared/src/main/scala/pact4s/ProviderInfoBuilder.scala
@@ -169,7 +169,7 @@ final case class ProviderInfoBuilder(
           providerInfo,
           PactBrokerWithSelectors(
             brokerUrl
-          ).withPendingPactsDisabled
+          )
             .withOptionalAuth(auth)
             .withSelectors(tags.map(tag => ConsumerVersionSelector().withTag(tag)))
             .withInsecureTLS(insecureTLS)
@@ -283,7 +283,7 @@ object PactSource {
     *   https://docs.pact.io/pact_broker/advanced_topics/pending_pacts for information on pending and WIP pacts
     *
     * @param enablePending
-    *   enable pending pacts. On by default. If enabled, [[providerTags]] must be provided.
+    *   enable pending pacts. Off by default. If enabled, [[providerTags]] must be provided.
     * @see
     *   also the master issue for pending pacts https://github.com/pact-foundation/pact_broker/issues/320
     *
@@ -317,7 +317,7 @@ object PactSource {
       brokerUrl: String,
       insecureTLS: Boolean = false,
       auth: Option[Authentication] = None,
-      enablePending: Boolean = true,
+      enablePending: Boolean = false,
       includeWipPactsSince: WipPactsSince = WipPactsSince.never,
       providerTags: Option[ProviderTags] = None,
       selectors: List[ConsumerVersionSelector] = List(ConsumerVersionSelector())

--- a/shared/src/main/scala/pact4s/ProviderInfoBuilder.scala
+++ b/shared/src/main/scala/pact4s/ProviderInfoBuilder.scala
@@ -307,7 +307,7 @@ object PactSource {
     * {{{
     *   PactBrokerWithSelectors(
     *     brokerUrl = "https://test.pact.dius.com.au"
-    *   ).withProviderTags(ProviderTags.one("MAIN"))
+    *   ).withPendingPactsEnabled(ProviderTags("MAIN"))
     *     .withAuth(BasicAuth("dXfltyFMgNOFZAxr8io9wJ37iUpY42M", "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"))
     *     .withWipPactsSince(WipPactsSince.instant(Instant.EPOCH))
     *     .withSelectors(ConsumerVersionSelector())

--- a/shared/src/main/scala/pact4s/ProviderTags.scala
+++ b/shared/src/main/scala/pact4s/ProviderTags.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021-2021 io.github.jbwheatley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pact4s
+
+final case class ProviderTags(head: String, tail: List[String]) {
+  def ::(tag: String): ProviderTags        = ProviderTags(tag, head :: tail)
+  private[pact4s] def toList: List[String] = head :: tail
+}
+
+object ProviderTags {
+  def one(tag: String): ProviderTags = ProviderTags(tag, Nil)
+
+  def fromList(tags: List[String]): Option[ProviderTags] = tags match {
+    case head :: tail => Some(ProviderTags(head, tail))
+    case Nil          => None
+  }
+}

--- a/shared/src/main/scala/pact4s/ProviderTags.scala
+++ b/shared/src/main/scala/pact4s/ProviderTags.scala
@@ -22,7 +22,7 @@ final case class ProviderTags(head: String, tail: List[String]) {
 }
 
 object ProviderTags {
-  def apply(tag: String): ProviderTags = ProviderTags(tag, Nil)
+  def apply(tag: String, rest: String*): ProviderTags = ProviderTags(tag, rest.toList)
 
   def fromList(tags: List[String]): Option[ProviderTags] = tags match {
     case head :: tail => Some(ProviderTags(head, tail))

--- a/shared/src/main/scala/pact4s/ProviderTags.scala
+++ b/shared/src/main/scala/pact4s/ProviderTags.scala
@@ -22,7 +22,7 @@ final case class ProviderTags(head: String, tail: List[String]) {
 }
 
 object ProviderTags {
-  def apply(tag: String, rest: String*): ProviderTags = ProviderTags(tag, rest: _*)
+  def apply(tag: String): ProviderTags = ProviderTags(tag, Nil)
 
   def fromList(tags: List[String]): Option[ProviderTags] = tags match {
     case head :: tail => Some(ProviderTags(head, tail))

--- a/shared/src/main/scala/pact4s/ProviderTags.scala
+++ b/shared/src/main/scala/pact4s/ProviderTags.scala
@@ -22,7 +22,7 @@ final case class ProviderTags(head: String, tail: List[String]) {
 }
 
 object ProviderTags {
-  def one(tag: String): ProviderTags = ProviderTags(tag, Nil)
+  def apply(tag: String, rest: String*): ProviderTags = ProviderTags(tag, rest: _*)
 
   def fromList(tags: List[String]): Option[ProviderTags] = tags match {
     case head :: tail => Some(ProviderTags(head, tail))

--- a/shared/src/test/scala/pact4s/MockProviderServer.scala
+++ b/shared/src/test/scala/pact4s/MockProviderServer.scala
@@ -14,7 +14,6 @@ import org.http4s.headers.`WWW-Authenticate`
 import org.http4s.implicits.http4sKleisliResponseSyntaxOptionT
 import org.http4s.server.Server
 import pact4s.Authentication.BasicAuth
-import pact4s.PactSource.PactBrokerWithSelectors.ProviderTags
 import pact4s.PactSource.{FileSource, PactBrokerWithSelectors}
 
 import java.io.File
@@ -123,8 +122,8 @@ class MockProviderServer(isRequestResponse: Boolean = true) {
       name = providerName,
       pactSource = PactBrokerWithSelectors(
         brokerUrl = "https://test.pact.dius.com.au"
-      ).withAuth(BasicAuth("dXfltyFMgNOFZAxr8io9wJ37iUpY42M", "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"))
-        .withPendingPactsEnabled(ProviderTags.one("SNAPSHOT"))
+      ).withProviderTags(ProviderTags.one("SNAPSHOT"))
+        .withAuth(BasicAuth("dXfltyFMgNOFZAxr8io9wJ37iUpY42M", "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"))
         .withSelectors(ConsumerVersionSelector())
     ).withPort(port)
       .withOptionalVerificationSettings(verificationSettings)

--- a/shared/src/test/scala/pact4s/MockProviderServer.scala
+++ b/shared/src/test/scala/pact4s/MockProviderServer.scala
@@ -122,7 +122,7 @@ class MockProviderServer(isRequestResponse: Boolean = true) {
       name = providerName,
       pactSource = PactBrokerWithSelectors(
         brokerUrl = "https://test.pact.dius.com.au"
-      ).withProviderTags(ProviderTags.one("SNAPSHOT"))
+      ).withProviderTags(ProviderTags("SNAPSHOT"))
         .withAuth(BasicAuth("dXfltyFMgNOFZAxr8io9wJ37iUpY42M", "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"))
         .withSelectors(ConsumerVersionSelector())
     ).withPort(port)

--- a/shared/src/test/scala/pact4s/MockProviderServer.scala
+++ b/shared/src/test/scala/pact4s/MockProviderServer.scala
@@ -122,7 +122,7 @@ class MockProviderServer(isRequestResponse: Boolean = true) {
       name = providerName,
       pactSource = PactBrokerWithSelectors(
         brokerUrl = "https://test.pact.dius.com.au"
-      ).withProviderTags(ProviderTags("SNAPSHOT"))
+      ).withPendingPactsEnabled(ProviderTags("SNAPSHOT"))
         .withAuth(BasicAuth("dXfltyFMgNOFZAxr8io9wJ37iUpY42M", "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"))
         .withSelectors(ConsumerVersionSelector())
     ).withPort(port)

--- a/shared/src/test/scala/pact4s/PactBrokerWithSelectorsSpec.scala
+++ b/shared/src/test/scala/pact4s/PactBrokerWithSelectorsSpec.scala
@@ -1,0 +1,26 @@
+package pact4s
+
+import munit.CatsEffectSuite
+import pact4s.PactSource.PactBrokerWithSelectors
+import pact4s.PactSource.PactBrokerWithSelectors.WipPactsSince
+
+import java.time.Instant
+
+class PactBrokerWithSelectorsSpec extends CatsEffectSuite {
+  test("pending enabled but no provider tags should throw IllegalArgumentException") {
+    intercept[IllegalArgumentException](PactBrokerWithSelectors("brokerUrl").withOptionalProviderTags(None))
+  }
+
+  test("pending disabled but WIP enabled should throw IllegalArgumentException") {
+    intercept[IllegalArgumentException](
+      PactBrokerWithSelectors("brokerUrl").withPendingPactsDisabled.withWipPactsSince(
+        WipPactsSince.instant(Instant.now)
+      )
+    )
+  }
+
+  test("pending disabled but giving provider tags set should re-enable pending") {
+    val p = PactBrokerWithSelectors("brokerUrl").withPendingPacts(false).withProviderTags(ProviderTags.one("TAG"))
+    assert(p.enablePending)
+  }
+}

--- a/shared/src/test/scala/pact4s/PactBrokerWithSelectorsSpec.scala
+++ b/shared/src/test/scala/pact4s/PactBrokerWithSelectorsSpec.scala
@@ -8,19 +8,35 @@ import java.time.Instant
 
 class PactBrokerWithSelectorsSpec extends CatsEffectSuite {
   test("pending enabled but no provider tags should throw IllegalArgumentException") {
-    intercept[IllegalArgumentException](PactBrokerWithSelectors("brokerUrl").withOptionalProviderTags(None))
-  }
-
-  test("pending disabled but WIP enabled should throw IllegalArgumentException") {
     intercept[IllegalArgumentException](
-      PactBrokerWithSelectors("brokerUrl").withPendingPactsDisabled.withWipPactsSince(
-        WipPactsSince.instant(Instant.now)
-      )
+      PactBrokerWithSelectors("brokerUrl").withPendingPacts(true).withOptionalProviderTags(None).validate()
     )
   }
 
-  test("pending disabled but giving provider tags set should re-enable pending") {
-    val p = PactBrokerWithSelectors("brokerUrl").withPendingPacts(false).withProviderTags(ProviderTags.one("TAG"))
+  test("WIP enabled but no provider tags should throw IllegalArgumentException") {
+    intercept[IllegalArgumentException](
+      PactBrokerWithSelectors("brokerUrl")
+        .withWipPactsSince(
+          WipPactsSince.instant(Instant.now)
+        )
+        .validate()
+    )
+  }
+
+  test("WIP enabled should turn on pending") {
+    val p = PactBrokerWithSelectors("brokerUrl").withWipPactsSince(
+      WipPactsSince.instant(Instant.now)
+    )
     assert(p.enablePending)
+  }
+
+  test("withPendingPacts(false) should turn off WIP pacts") {
+    val p = PactBrokerWithSelectors("brokerUrl")
+      .withWipPactsSince(
+        WipPactsSince.instant(Instant.now)
+      )
+      .withPendingPacts(false)
+    p.validate()
+    assertEquals(p.includeWipPactsSince, WipPactsSince.never)
   }
 }

--- a/weaver-pact/src/test/scala/pact4s/weaver/MessagePactVerifierBrokerWeaverTestSuite.scala
+++ b/weaver-pact/src/test/scala/pact4s/weaver/MessagePactVerifierBrokerWeaverTestSuite.scala
@@ -15,8 +15,7 @@ object MessagePactVerifierBrokerWeaverTestSuite extends SimpleIOSuite with Messa
       verifyPacts(
         publishVerificationResults = Some(
           PublishVerificationResults(
-            providerVersion = "SNAPSHOT",
-            providerTags = Nil
+            providerVersion = "SNAPSHOT"
           )
         )
       )

--- a/weaver-pact/src/test/scala/pact4s/weaver/RequestResponsePactVerifierBrokerWeaverSuite.scala
+++ b/weaver-pact/src/test/scala/pact4s/weaver/RequestResponsePactVerifierBrokerWeaverSuite.scala
@@ -19,8 +19,7 @@ object RequestResponsePactVerifierBrokerWeaverSuite extends IOSuite with PactVer
       verifyPacts(
         publishVerificationResults = Some(
           PublishVerificationResults(
-            providerVersion = "SNAPSHOT",
-            providerTags = Nil
+            providerVersion = "SNAPSHOT"
           )
         )
       )


### PR DESCRIPTION
Response to #81 

Trying to keep the routes to illegal states at a minimum, while adding enough build options that the API isn't too cumbersome to use, especially in the case where settings are read from config. Illegal setting combinations will fail fast with an IllegalArgumentException explaining why the combination is illegal. 

I've also turned on pending pacts by default, however see discussion on #69. This may not be the way to go. 

Examples: 

Good: 
```scala
PactBrokerWithSelectors("brokerUrl")
  .withProviderTags(ProviderTags("MAIN"))
  .withWipPactsSince(WipPactsSince.instant(Instant.EPOCH))
  .withAuth(...)

PactBrokerWithSelectors("brokerUrl")
  .withPendingPacts(true)
  .withProviderTags(ProviderTags("MAIN"))
  .withAuth(...)

PactBrokerWithSelectors("brokerUrl")
  .withAuth(...)
```

Can fail:
```scala
val enabled: Boolean = ??? //read from config
val tags: List[String] = ???
val wipPactsSince: Option[LocalDate] = ???
PactBrokerWithSelectors("brokerUrl")
  .withPendingPacts(enabled)
  .withOptionalProviderTags(ProviderTags.fromList(tags)) //throws IllegalArgumentException if None and enabled=false
  .withWipPactsSince(WipPactsSince.optionalLocalDate(wipPactsSince)) // //throws IllegalArgumentException if Some(_) and ProviderTags.fromList(tags) is None
  .withAuth(...)
```