### PR TITLE
add configurable timeout to verification step (that actually fails the tests)

### DIFF
--- a/munit-cats-effect-pact/src/main/scala/pact4s/munit/PactVerifier.scala
+++ b/munit-cats-effect-pact/src/main/scala/pact4s/munit/PactVerifier.scala
@@ -16,12 +16,17 @@
 
 package pact4s.munit
 
+import au.com.dius.pact.provider.VerificationResult
+import cats.effect.IO
 import munit.internal.console.Printers
-import munit.{Assertions, Location}
+import munit.{CatsEffectSuite, Location}
 import pact4s.{Pact4sLogger, PactVerifyResources}
 import sourcecode.{File, FileName, Line}
 
-trait PactVerifier extends Assertions with PactVerifyResources with Pact4sLogger {
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration.FiniteDuration
+
+trait PactVerifier extends PactVerifyResources with Pact4sLogger { self: CatsEffectSuite =>
   override private[pact4s] def skip(message: String)(implicit fileName: FileName, file: File, line: Line): Unit = {
     implicit val loc = new Location(file.value, line.value)
     Printers.log(message)
@@ -30,9 +35,27 @@ trait PactVerifier extends Assertions with PactVerifyResources with Pact4sLogger
 
   override private[pact4s] def failure(message: String)(implicit fileName: FileName, file: File, line: Line): Nothing =
     fail(message)(new Location(file.value, line.value))
+
+  override private[pact4s] def runWithTimeout(
+      verify: => VerificationResult,
+      timeout: Option[FiniteDuration]
+  ): Either[TimeoutException, VerificationResult] =
+    timeout match {
+      case Some(timeout) =>
+        IO.delay(verify)
+          .timeout(timeout)
+          .attempt
+          .flatMap[Either[TimeoutException, VerificationResult]] {
+            case Left(ex: TimeoutException) => IO(Left(ex))
+            case Left(ex)                   => IO.raiseError(ex)
+            case Right(value)               => IO(Right(value))
+          }
+          .unsafeRunSync()
+      case None => Right(verify)
+    }
 }
 
-trait MessagePactVerifier extends PactVerifier {
+trait MessagePactVerifier extends PactVerifier { _: CatsEffectSuite =>
   def messages: ResponseFactory
   override def responseFactory: Option[ResponseFactory] = Some(messages)
 }


### PR DESCRIPTION
I was running the pact verification step against a stub server, and the tests failed due to the operation timing out. However, because the pacts were pending, the overall build still passed. The build should not pass if the pact test didn't actually return a result. 