### PR TITLE
feat: 🚀 Add params attribute to the ProviderState case class

### DIFF
--- a/circe/src/test/scala/pact4s/circe/ImplicitsTests.scala
+++ b/circe/src/test/scala/pact4s/circe/ImplicitsTests.scala
@@ -1,0 +1,65 @@
+package pact4s.circe
+
+import io.circe.parser.parse
+import munit.FunSuite
+import pact4s.circe.implicits.providerStateCodec
+import pact4s.provider.ProviderState
+
+class ImplicitsTests extends FunSuite {
+
+  private def checkJsonRead(json: String, expectedProviderState: ProviderState): Unit =
+    parse(json).flatMap(_.as[ProviderState]) match {
+      case Right(actualProviderState) => assertEquals(actualProviderState, expectedProviderState)
+      case Left(err)                  => fail(s"Parsing json failed", err)
+    }
+
+  test("ProviderState read no param") {
+    checkJsonRead(
+      """{"state": "some state"}""",
+      ProviderState("some state", Map())
+    )
+  }
+
+  test("ProviderState read string param") {
+    checkJsonRead(
+      """{"state": "some state", "params": {"someKey": "some string"}}""",
+      ProviderState("some state", Map("someKey" -> "some string"))
+    )
+  }
+
+  test("ProviderState read int param") {
+    checkJsonRead(
+      """{"state": "some state", "params": {"someKey": 42}}""",
+      ProviderState("some state", Map("someKey" -> "42"))
+    )
+  }
+
+  test("ProviderState read null param") {
+    checkJsonRead(
+      """{"state": "some state", "params": {"someKey": null}}""",
+      ProviderState("some state", Map())
+    )
+  }
+
+  test("ProviderState read boolean param") {
+    checkJsonRead(
+      """{"state": "some state", "params": {"someKey": true}}""",
+      ProviderState("some state", Map("someKey" -> "true"))
+    )
+  }
+
+  test("ProviderState read object param") {
+    checkJsonRead(
+      """{"state": "some state", "params": {"someKey": {"innerKey": "innerValue"}}}""",
+      ProviderState("some state", Map("someKey" -> """{"innerKey":"innerValue"}"""))
+    )
+  }
+
+  test("ProviderState read array param") {
+    checkJsonRead(
+      """{"state": "some state", "params": {"someKey": [1, 2, 3]}}""",
+      ProviderState("some state", Map("someKey" -> """[1,2,3]"""))
+    )
+  }
+
+}

--- a/play-json/src/main/scala/pact4s/playjson/implicits.scala
+++ b/play-json/src/main/scala/pact4s/playjson/implicits.scala
@@ -20,7 +20,8 @@ import au.com.dius.pact.core.model.messaging.Message
 import pact4s.algebras.{MessagePactDecoder, PactBodyJsonEncoder, PactDslJsonBodyEncoder}
 import pact4s.playjson.JsonConversion.jsonToPactDslJsonBody
 import pact4s.provider.ProviderState
-import play.api.libs.json.{Format, Json, Reads, Writes}
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json._
 
 import scala.util.Try
 
@@ -34,5 +35,35 @@ object implicits {
   implicit def messagePactDecoder[A](implicit reads: Reads[A]): MessagePactDecoder[A] = (message: Message) =>
     Try(Json.parse(message.contentsAsString()).as[A]).toEither
 
-  implicit val providerStateFormat: Format[ProviderState] = Json.format[ProviderState]
+  implicit val providerStateWrites: Writes[ProviderState] = Json.writes[ProviderState]
+
+  implicit val providerStateReads: Reads[ProviderState] = {
+
+    def jsonAsString(json: JsValue): Option[String] =
+      json match {
+        case JsNull               => None
+        case JsTrue               => Some("true")
+        case JsFalse              => Some("false")
+        case JsNumber(num)        => Some(num.toString())
+        case JsString(str)        => Some(str)
+        case jsArr: JsArray       => Some(Json.stringify(jsArr))
+        case jsonObject: JsObject => Some(Json.stringify(jsonObject))
+      }
+
+    val state = (JsPath \ "state").read[String]
+    val params = (JsPath \ "params")
+      .readNullable[JsObject]
+      .map(obj =>
+        obj
+          .map(
+            _.value
+              .map { case (k, v) => k -> jsonAsString(v) }
+              .collect { case (k, Some(v)) => k -> v }
+              .toMap
+          )
+          .getOrElse(Map.empty)
+      )
+    (state and params)(ProviderState.apply _)
+  }
+
 }

--- a/play-json/src/test/scala/pact4s/playjson/ImplicitsTests.scala
+++ b/play-json/src/test/scala/pact4s/playjson/ImplicitsTests.scala
@@ -1,0 +1,62 @@
+package pact4s.playjson
+
+import munit.FunSuite
+import pact4s.playjson.implicits.providerStateReads
+import pact4s.provider.ProviderState
+import play.api.libs.json.Json
+
+class ImplicitsTests extends FunSuite {
+
+  private def checkJsonRead(json: String, expectedProviderState: ProviderState): Unit =
+    assertEquals(Json.parse(json).as[ProviderState], expectedProviderState)
+
+  test("ProviderState read no param") {
+    checkJsonRead(
+      """{"state": "some state"}""",
+      ProviderState("some state", Map())
+    )
+  }
+
+  test("ProviderState read string param") {
+    checkJsonRead(
+      """{"state": "some state", "params": {"someKey": "some string"}}""",
+      ProviderState("some state", Map("someKey" -> "some string"))
+    )
+  }
+
+  test("ProviderState read int param") {
+    checkJsonRead(
+      """{"state": "some state", "params": {"someKey": 42}}""",
+      ProviderState("some state", Map("someKey" -> "42"))
+    )
+  }
+
+  test("ProviderState read null param") {
+    checkJsonRead(
+      """{"state": "some state", "params": {"someKey": null}}""",
+      ProviderState("some state", Map())
+    )
+  }
+
+  test("ProviderState read boolean param") {
+    checkJsonRead(
+      """{"state": "some state", "params": {"someKey": true}}""",
+      ProviderState("some state", Map("someKey" -> "true"))
+    )
+  }
+
+  test("ProviderState read object param") {
+    checkJsonRead(
+      """{"state": "some state", "params": {"someKey": {"innerKey": "innerValue"}}}""",
+      ProviderState("some state", Map("someKey" -> """{"innerKey":"innerValue"}"""))
+    )
+  }
+
+  test("ProviderState read array param") {
+    checkJsonRead(
+      """{"state": "some state", "params": {"someKey": [1, 2, 3]}}""",
+      ProviderState("some state", Map("someKey" -> """[1,2,3]"""))
+    )
+  }
+
+}

--- a/shared/src/main/scala/pact4s/provider/ProviderState.scala
+++ b/shared/src/main/scala/pact4s/provider/ProviderState.scala
@@ -17,7 +17,7 @@
 package pact4s
 package provider
 
-/** entity passed to the mock provider state setup endpoint by pact-jvm before running consumer pacts with state. A
-  * circe.Decoder instance is provided in the pact4s-circe module.
+/** Entity passed to the mock provider state setup endpoint by pact-jvm before running consumer pacts with state.
+  * Decoders are provided in each JSON library module (circe or play-json).
   */
-final case class ProviderState(state: String) extends AnyVal
+final case class ProviderState(state: String, params: Map[String, String] = Map.empty)


### PR DESCRIPTION
This solves #120 

As discussed on the origin issue, for simplicity and in order to avoid the burden of `Map[String,Any]` the parameters are typed as `Map[String,String]`.