### PR TITLE
immediate shutdown of test ember server

### DIFF
--- a/munit-cats-effect-pact/src/main/scala/pact4s/munit/PactVerifier.scala
+++ b/munit-cats-effect-pact/src/main/scala/pact4s/munit/PactVerifier.scala
@@ -40,9 +40,9 @@ trait PactVerifier extends PactVerifyResources with Pact4sLogger { self: CatsEff
       verify: () => VerificationResult,
       timeout: Option[FiniteDuration]
   ): Either[TimeoutException, VerificationResult] =
-    timeout match {
+    (timeout match {
       case Some(timeout) =>
-        IO.delay(verify())
+        IO(verify())
           .timeout(timeout)
           .attempt
           .flatMap[Either[TimeoutException, VerificationResult]] {
@@ -50,9 +50,8 @@ trait PactVerifier extends PactVerifyResources with Pact4sLogger { self: CatsEff
             case Left(ex)                   => IO.raiseError(ex)
             case Right(value)               => IO(Right(value))
           }
-          .unsafeRunSync()
-      case None => Right(verify())
-    }
+      case None => IO(Right(verify()))
+    }).unsafeRunSync()
 }
 
 trait MessagePactVerifier extends PactVerifier { self: CatsEffectSuite =>

--- a/shared/src/test/scala/pact4s/MockProviderServer.scala
+++ b/shared/src/test/scala/pact4s/MockProviderServer.scala
@@ -21,6 +21,7 @@ import sourcecode.{File => SCFile}
 
 import java.io.File
 import java.net.URL
+import scala.concurrent.duration.DurationInt
 
 class MockProviderServer(port: Int, hasFeatureX: Boolean = false)(implicit file: SCFile) {
 
@@ -32,6 +33,7 @@ class MockProviderServer(port: Int, hasFeatureX: Boolean = false)(implicit file:
       .withHost(Host.fromString("localhost").get)
       .withPort(Port.fromInt(port).get)
       .withHttpApp(middleware(app))
+      .withShutdownTimeout(1.seconds)
       .build
 
   private implicit val entityDecoder: EntityDecoder[IO, ProviderState] = {


### PR DESCRIPTION
test servers were taking the default 30 seconds to shutdown, which meant verification test suites were taking much longer than they needed to 