### PR TITLE
Handle empty params (JsonValue null) in StateChanger - java8

### DIFF
--- a/shared/src/main/scala/pact4s/StateChanger.scala
+++ b/shared/src/main/scala/pact4s/StateChanger.scala
@@ -60,7 +60,7 @@ private[pact4s] object StateChanger {
       def handle(t: HttpExchange): Unit = {
         val stateAndResponse: Option[(String, Map[String, String], String)] = Try {
           val json        = JsonParser.parseStream(t.getRequestBody)
-          val maybeParams = Try(json.get("params")).toOption.map(_.asObject())
+          val maybeParams = Try(json.get("params").asObject).toOption
           val params: Map[String, String] = maybeParams
             .map(
               _.getEntries.asScala


### PR DESCRIPTION
The StateChanger in **java8** branch did not handle properly **given** statement without params:

In such case exception was thrown
* it could not map on json null value
* catched in above try and did not report any issue 