### PR TITLE
feat(verifier): be able to defined a state change before hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ val provider: ProviderInfoBuilder =
 
 In this case, under the hood `pact4s` creates its own http server with an endpoint that receives the state-change requests from `pact-jvm`. By default, this server receieves requests to `localhost:64646/pact4s-state-change`. In case this clashes with any other server you are running, the url components can be overriden with `ProviderInfoBuilder#withStateChangeFunctionConfigOverrides`.
 
-It is also possible to define a before/after hook (`() => Unit`) that will run at each state change before/after the state-change function:
+It is also possible to define a before hook (`() => Unit`) that will run at each state change before the state-change function:
 
 ```scala
 val provider: ProviderInfoBuilder = 
@@ -433,7 +433,6 @@ val provider: ProviderInfoBuilder =
       case _ => ()
     }
     .withBeforeEach(() => cleanTheState())
-    .withAfterEach(() => afterHook())
   )
 ```
 

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ val provider: ProviderInfoBuilder =
 
 In this case, under the hood `pact4s` creates its own http server with an endpoint that receives the state-change requests from `pact-jvm`. By default, this server receieves requests to `localhost:64646/pact4s-state-change`. In case this clashes with any other server you are running, the url components can be overriden with `ProviderInfoBuilder#withStateChangeFunctionConfigOverrides`.
 
-It is also possible to define a "before hook" that will run at each state change before the state-change function:
+It is also possible to define a "before hook" and/or "after hook" that will run at each state change before/after the state-change function:
 
 ```scala
 val provider: ProviderInfoBuilder = 
@@ -433,7 +433,10 @@ val provider: ProviderInfoBuilder =
   } { 
    case ProviderState("state", params) => doSomething()
    case _ => ()
-  } 
+  } {
+    // This is the after hook
+    () => afterHook()
+  }
 ```
 
 ## Logging 

--- a/README.md
+++ b/README.md
@@ -423,6 +423,19 @@ val provider: ProviderInfoBuilder =
 
 In this case, under the hood `pact4s` creates its own http server with an endpoint that receives the state-change requests from `pact-jvm`. By default, this server receieves requests to `localhost:64646/pact4s-state-change`. In case this clashes with any other server you are running, the url components can be overriden with `ProviderInfoBuilder#withStateChangeFunctionConfigOverrides`.
 
+It is also possible to define a "before hook" that will run at each state change before the state-change function:
+
+```scala
+val provider: ProviderInfoBuilder = 
+  ProviderInfoBuilder().withStateChangeFunction {
+    // This is the before hook    
+    () => cleanTheState()
+  } { 
+   case ProviderState("state", params) => doSomething()
+   case _ => ()
+  } 
+```
+
 ## Logging 
 
 - For consumer tests (forging pacts), you can enable additional logging from `pact-jvm` with the logger `au.com.dius.pact.consumer`.

--- a/README.md
+++ b/README.md
@@ -423,20 +423,18 @@ val provider: ProviderInfoBuilder =
 
 In this case, under the hood `pact4s` creates its own http server with an endpoint that receives the state-change requests from `pact-jvm`. By default, this server receieves requests to `localhost:64646/pact4s-state-change`. In case this clashes with any other server you are running, the url components can be overriden with `ProviderInfoBuilder#withStateChangeFunctionConfigOverrides`.
 
-It is also possible to define a "before hook" and/or "after hook" that will run at each state change before/after the state-change function:
+It is also possible to define a before/after hook (`() => Unit`) that will run at each state change before/after the state-change function:
 
 ```scala
 val provider: ProviderInfoBuilder = 
-  ProviderInfoBuilder().withStateChangeFunction {
-    // This is the before hook    
-    () => cleanTheState()
-  } { 
-   case ProviderState("state", params) => doSomething()
-   case _ => ()
-  } {
-    // This is the after hook
-    () => afterHook()
-  }
+  ProviderInfoBuilder().withStateManagementFunction(
+    StateManagementFunction {
+      case ProviderState("state", params) => doSomething()
+      case _ => ()
+    }
+    .withBeforeEach(() => cleanTheState())
+    .withAfterEach(() => afterHook())
+  )
 ```
 
 ## Logging 

--- a/example/provider/src/test/scala/http.provider/MunitVerifyPacts.scala
+++ b/example/provider/src/test/scala/http.provider/MunitVerifyPacts.scala
@@ -76,7 +76,7 @@ class MunitVerifyPacts extends CatsEffectSuite with PactVerifier {
         case ProviderState("resource does not exist", _) => () // Nothing to do
         case _: ProviderState                            => ???
       }
-    )
+    )(() => ())
     .withRequestFiltering(requestFilter)
 
   test("Verify pacts") {

--- a/example/provider/src/test/scala/http.provider/MunitVerifyPacts.scala
+++ b/example/provider/src/test/scala/http.provider/MunitVerifyPacts.scala
@@ -10,6 +10,7 @@ import org.http4s.server.Server
 import org.http4s.{BasicCredentials, HttpRoutes}
 import pact4s.munit.PactVerifier
 import pact4s.provider.ProviderRequestFilter.{NoOpFilter, SetHeaders}
+import pact4s.provider.StateManagement.StateManagementFunction
 import pact4s.provider._
 
 import java.io.File
@@ -67,8 +68,8 @@ class MunitVerifyPacts extends CatsEffectSuite with PactVerifier {
     )
   ).withHost("localhost")
     .withPort(1235)
-    .withStateChangeFunction(() => store.empty.unsafeRunSync())((state: ProviderState) =>
-      state match {
+    .withStateManagementFunction(
+      StateManagementFunction {
         case ProviderState("resource exists", params) =>
           val id    = params.get("id")
           val value = params.get("value").map(_.toInt)
@@ -76,7 +77,9 @@ class MunitVerifyPacts extends CatsEffectSuite with PactVerifier {
         case ProviderState("resource does not exist", _) => () // Nothing to do
         case _: ProviderState                            => ???
       }
-    )(() => ())
+        .withBeforeEach(() => store.empty.unsafeRunSync())
+        .withAfterEach(() => ()) // only to highlight and test the API
+    )
     .withRequestFiltering(requestFilter)
 
   test("Verify pacts") {

--- a/example/provider/src/test/scala/http.provider/MunitVerifyPacts.scala
+++ b/example/provider/src/test/scala/http.provider/MunitVerifyPacts.scala
@@ -78,7 +78,6 @@ class MunitVerifyPacts extends CatsEffectSuite with PactVerifier {
         case _: ProviderState                            => ???
       }
         .withBeforeEach(() => store.empty.unsafeRunSync())
-        .withAfterEach(() => ()) // only to highlight and test the API
     )
     .withRequestFiltering(requestFilter)
 

--- a/example/provider/src/test/scala/http.provider/ScalaTestVerifyPacts.scala
+++ b/example/provider/src/test/scala/http.provider/ScalaTestVerifyPacts.scala
@@ -84,7 +84,6 @@ class ScalaTestVerifyPacts extends AnyFlatSpec with BeforeAndAfterAll with PactV
         case _                                           => ???
       }
         .withBeforeEach(() => store.empty.unsafeRunSync())
-        .withAfterEach(() => ()) // only to highlight and test the API
     )
     .withRequestFiltering(requestFilter)
 

--- a/example/provider/src/test/scala/http.provider/ScalaTestVerifyPacts.scala
+++ b/example/provider/src/test/scala/http.provider/ScalaTestVerifyPacts.scala
@@ -82,7 +82,7 @@ class ScalaTestVerifyPacts extends AnyFlatSpec with BeforeAndAfterAll with PactV
         case ProviderState("resource does not exist", _) => () // Nothing to do
         case _                                           => ???
       }
-    )
+    )(() => ())
     .withRequestFiltering(requestFilter)
 
   it should "Verify pacts" in {

--- a/models/src/main/scala/pact4s/provider/ProviderInfoBuilder.scala
+++ b/models/src/main/scala/pact4s/provider/ProviderInfoBuilder.scala
@@ -122,11 +122,11 @@ final class ProviderInfoBuilder private (
   }
 
   def withStateChangeFunction(stateChange: PartialFunction[ProviderState, Unit]): ProviderInfoBuilder =
-    withStateChangeFunction(() => ())(stateChange)
+    withStateChangeFunction(() => ())(stateChange)(() => ())
   def withStateChangeFunction(stateChangeBeforeHook: () => Unit)(
       stateChange: PartialFunction[ProviderState, Unit]
-  ): ProviderInfoBuilder =
-    copy(stateManagement = Some(StateManagement.StateManagementFunction(stateChange, stateChangeBeforeHook)))
+  )(stateChangeAfterHook: () => Unit): ProviderInfoBuilder =
+    copy(stateManagement = Some(StateManagement.StateManagementFunction(stateChange, stateChangeBeforeHook, stateChangeAfterHook)))
   def withStateChangeFunction(stateChange: ProviderState => Unit): ProviderInfoBuilder =
     withStateChangeFunction({ case x => stateChange(x) }: PartialFunction[ProviderState, Unit])
 

--- a/models/src/main/scala/pact4s/provider/ProviderInfoBuilder.scala
+++ b/models/src/main/scala/pact4s/provider/ProviderInfoBuilder.scala
@@ -23,6 +23,7 @@ import au.com.dius.pact.provider.{PactBrokerOptions, PactVerification, ProviderI
 import org.apache.hc.core5.http.HttpRequest
 import pact4s.provider.Authentication.{BasicAuth, TokenAuth}
 import pact4s.provider.PactSource.{FileSource, PactBroker, PactBrokerWithSelectors, PactBrokerWithTags}
+import pact4s.provider.StateManagement.StateManagementFunction
 import pact4s.provider.VerificationSettings.AnnotatedMethodVerificationSettings
 
 import java.net.URL
@@ -122,13 +123,12 @@ final class ProviderInfoBuilder private (
   }
 
   def withStateChangeFunction(stateChange: PartialFunction[ProviderState, Unit]): ProviderInfoBuilder =
-    withStateChangeFunction(() => ())(stateChange)(() => ())
-  def withStateChangeFunction(stateChangeBeforeHook: () => Unit)(
-      stateChange: PartialFunction[ProviderState, Unit]
-  )(stateChangeAfterHook: () => Unit): ProviderInfoBuilder =
-    copy(stateManagement = Some(StateManagement.StateManagementFunction(stateChange, stateChangeBeforeHook, stateChangeAfterHook)))
+    withStateManagementFunction(StateManagementFunction(stateChange))
   def withStateChangeFunction(stateChange: ProviderState => Unit): ProviderInfoBuilder =
     withStateChangeFunction({ case x => stateChange(x) }: PartialFunction[ProviderState, Unit])
+
+  def withStateManagementFunction(stateManagementFunction: StateManagementFunction): ProviderInfoBuilder =
+    copy(stateManagement = Some(stateManagementFunction))
 
   def withStateChangeFunctionConfigOverrides(
       overrides: StateManagement.StateManagementFunction => StateManagement.StateManagementFunction

--- a/models/src/main/scala/pact4s/provider/ProviderInfoBuilder.scala
+++ b/models/src/main/scala/pact4s/provider/ProviderInfoBuilder.scala
@@ -122,7 +122,11 @@ final class ProviderInfoBuilder private (
   }
 
   def withStateChangeFunction(stateChange: PartialFunction[ProviderState, Unit]): ProviderInfoBuilder =
-    copy(stateManagement = Some(StateManagement.StateManagementFunction(stateChange)))
+    withStateChangeFunction(() => ())(stateChange)
+  def withStateChangeFunction(stateChangeBeforeHook: () => Unit)(
+      stateChange: PartialFunction[ProviderState, Unit]
+  ): ProviderInfoBuilder =
+    copy(stateManagement = Some(StateManagement.StateManagementFunction(stateChange, stateChangeBeforeHook)))
   def withStateChangeFunction(stateChange: ProviderState => Unit): ProviderInfoBuilder =
     withStateChangeFunction({ case x => stateChange(x) }: PartialFunction[ProviderState, Unit])
 

--- a/models/src/main/scala/pact4s/provider/StateManagement.scala
+++ b/models/src/main/scala/pact4s/provider/StateManagement.scala
@@ -26,6 +26,7 @@ object StateManagement {
 
   final class StateManagementFunction private (
       private[pact4s] val stateChangeFunc: PartialFunction[ProviderState, Unit],
+      private[pact4s] val stateChangeBeforeHook: () => Unit,
       private[pact4s] val host: String,
       private[pact4s] val port: Int,
       private[pact4s] val endpoint: String
@@ -37,6 +38,7 @@ object StateManagement {
     ): StateManagementFunction =
       new StateManagementFunction(
         stateChangeFunc,
+        stateChangeBeforeHook,
         host = hostOverride,
         port = portOverride,
         endpoint = endpointOverride
@@ -47,7 +49,10 @@ object StateManagement {
   }
 
   object StateManagementFunction {
-    def apply(stateChangeFunc: PartialFunction[ProviderState, Unit]): StateManagementFunction =
-      new StateManagementFunction(stateChangeFunc, "localhost", 64646, "/pact4s-state-change")
+    def apply(
+        stateChangeFunc: PartialFunction[ProviderState, Unit],
+        stateChangeBeforeHook: () => Unit
+    ): StateManagementFunction =
+      new StateManagementFunction(stateChangeFunc, stateChangeBeforeHook, "localhost", 64646, "/pact4s-state-change")
   }
 }

--- a/models/src/main/scala/pact4s/provider/StateManagement.scala
+++ b/models/src/main/scala/pact4s/provider/StateManagement.scala
@@ -27,7 +27,6 @@ object StateManagement {
   final class StateManagementFunction private (
       private[pact4s] val stateChangeFunc: PartialFunction[ProviderState, Unit],
       private[pact4s] val stateChangeBeforeHook: () => Unit,
-      private[pact4s] val stateChangeAfterHook: () => Unit,
       private[pact4s] val host: String,
       private[pact4s] val port: Int,
       private[pact4s] val endpoint: String
@@ -40,17 +39,13 @@ object StateManagement {
       new StateManagementFunction(
         stateChangeFunc,
         stateChangeBeforeHook,
-        stateChangeAfterHook,
         host = hostOverride,
         port = portOverride,
         endpoint = endpointOverride
       )
 
     def withBeforeEach(beforeHook: () => Unit): StateManagementFunction =
-      new StateManagementFunction(stateChangeFunc, beforeHook, stateChangeAfterHook, host, port, endpoint)
-
-    def withAfterEach(afterHook: () => Unit): StateManagementFunction =
-      new StateManagementFunction(stateChangeFunc, stateChangeBeforeHook, afterHook, host, port, endpoint)
+      new StateManagementFunction(stateChangeFunc, beforeHook, host, port, endpoint)
 
     private val slashedEndpoint       = if (!endpoint.startsWith("/")) "/" + endpoint else endpoint
     private[provider] val url: String = s"http://$host:$port$slashedEndpoint"
@@ -61,7 +56,7 @@ object StateManagement {
     def apply(
         stateChangeFunc: PartialFunction[ProviderState, Unit]
     ): StateManagementFunction =
-      new StateManagementFunction(stateChangeFunc, () => (), () => (), "localhost", 64646, "/pact4s-state-change")
+      new StateManagementFunction(stateChangeFunc, () => (), "localhost", 64646, "/pact4s-state-change")
 
   }
 }

--- a/models/src/main/scala/pact4s/provider/StateManagement.scala
+++ b/models/src/main/scala/pact4s/provider/StateManagement.scala
@@ -46,16 +46,22 @@ object StateManagement {
         endpoint = endpointOverride
       )
 
+    def withBeforeEach(beforeHook: () => Unit): StateManagementFunction =
+      new StateManagementFunction(stateChangeFunc, beforeHook, stateChangeAfterHook, host, port, endpoint)
+
+    def withAfterEach(afterHook: () => Unit): StateManagementFunction =
+      new StateManagementFunction(stateChangeFunc, stateChangeBeforeHook, afterHook, host, port, endpoint)
+
     private val slashedEndpoint       = if (!endpoint.startsWith("/")) "/" + endpoint else endpoint
     private[provider] val url: String = s"http://$host:$port$slashedEndpoint"
   }
 
   object StateManagementFunction {
+
     def apply(
-        stateChangeFunc: PartialFunction[ProviderState, Unit],
-        stateChangeBeforeHook: () => Unit,
-        stateChangeAfterHook: () => Unit
+        stateChangeFunc: PartialFunction[ProviderState, Unit]
     ): StateManagementFunction =
-      new StateManagementFunction(stateChangeFunc, stateChangeBeforeHook, stateChangeAfterHook, "localhost", 64646, "/pact4s-state-change")
+      new StateManagementFunction(stateChangeFunc, () => (), () => (), "localhost", 64646, "/pact4s-state-change")
+
   }
 }

--- a/models/src/main/scala/pact4s/provider/StateManagement.scala
+++ b/models/src/main/scala/pact4s/provider/StateManagement.scala
@@ -27,6 +27,7 @@ object StateManagement {
   final class StateManagementFunction private (
       private[pact4s] val stateChangeFunc: PartialFunction[ProviderState, Unit],
       private[pact4s] val stateChangeBeforeHook: () => Unit,
+      private[pact4s] val stateChangeAfterHook: () => Unit,
       private[pact4s] val host: String,
       private[pact4s] val port: Int,
       private[pact4s] val endpoint: String
@@ -39,6 +40,7 @@ object StateManagement {
       new StateManagementFunction(
         stateChangeFunc,
         stateChangeBeforeHook,
+        stateChangeAfterHook,
         host = hostOverride,
         port = portOverride,
         endpoint = endpointOverride
@@ -51,8 +53,9 @@ object StateManagement {
   object StateManagementFunction {
     def apply(
         stateChangeFunc: PartialFunction[ProviderState, Unit],
-        stateChangeBeforeHook: () => Unit
+        stateChangeBeforeHook: () => Unit,
+        stateChangeAfterHook: () => Unit
     ): StateManagementFunction =
-      new StateManagementFunction(stateChangeFunc, stateChangeBeforeHook, "localhost", 64646, "/pact4s-state-change")
+      new StateManagementFunction(stateChangeFunc, stateChangeBeforeHook, stateChangeAfterHook, "localhost", 64646, "/pact4s-state-change")
   }
 }

--- a/shared/src/main/scala/pact4s/PactVerifyResources.scala
+++ b/shared/src/main/scala/pact4s/PactVerifyResources.scala
@@ -121,7 +121,7 @@ trait PactVerifyResources {
     val stateChanger: StateChanger =
       provider.stateManagement match {
         case Some(s: StateManagementFunction) =>
-          new StateChanger.SimpleServer(s.stateChangeFunc, s.host, s.port, s.endpoint)
+          new StateChanger.SimpleServer(s.stateChangeFunc, s.stateChangeBeforeHook, s.host, s.port, s.endpoint)
         case _ => StateChanger.NoOpStateChanger
       }
     stateChanger.start()

--- a/shared/src/main/scala/pact4s/PactVerifyResources.scala
+++ b/shared/src/main/scala/pact4s/PactVerifyResources.scala
@@ -121,7 +121,7 @@ trait PactVerifyResources {
     val stateChanger: StateChanger =
       provider.stateManagement match {
         case Some(s: StateManagementFunction) =>
-          new StateChanger.SimpleServer(s.stateChangeFunc, s.stateChangeBeforeHook, s.stateChangeAfterHook, s.host, s.port, s.endpoint)
+          new StateChanger.SimpleServer(s.stateChangeFunc, s.stateChangeBeforeHook, s.host, s.port, s.endpoint)
         case _ => StateChanger.NoOpStateChanger
       }
     stateChanger.start()

--- a/shared/src/main/scala/pact4s/PactVerifyResources.scala
+++ b/shared/src/main/scala/pact4s/PactVerifyResources.scala
@@ -121,7 +121,7 @@ trait PactVerifyResources {
     val stateChanger: StateChanger =
       provider.stateManagement match {
         case Some(s: StateManagementFunction) =>
-          new StateChanger.SimpleServer(s.stateChangeFunc, s.stateChangeBeforeHook, s.host, s.port, s.endpoint)
+          new StateChanger.SimpleServer(s.stateChangeFunc, s.stateChangeBeforeHook, s.stateChangeAfterHook, s.host, s.port, s.endpoint)
         case _ => StateChanger.NoOpStateChanger
       }
     stateChanger.start()

--- a/shared/src/main/scala/pact4s/StateChanger.scala
+++ b/shared/src/main/scala/pact4s/StateChanger.scala
@@ -38,6 +38,7 @@ private[pact4s] object StateChanger {
   class SimpleServer(
       stateChange: PartialFunction[ProviderState, Unit],
       stateChangeBeforeHook: () => Unit,
+      stateChangeAfterHook: () => Unit,
       host: String,
       port: Int,
       endpoint: String
@@ -97,6 +98,8 @@ private[pact4s] object StateChanger {
             .getOrElse(
               pact4sLogger.warn(s"No state change definition was provided for received state $s with parameters $ps")
             )
+          // Apply after hook
+          stateChangeAfterHook.apply()
         })
         stateChangeMaybeApplied match {
           case Failure(exception) =>

--- a/shared/src/main/scala/pact4s/StateChanger.scala
+++ b/shared/src/main/scala/pact4s/StateChanger.scala
@@ -38,7 +38,6 @@ private[pact4s] object StateChanger {
   class SimpleServer(
       stateChange: PartialFunction[ProviderState, Unit],
       stateChangeBeforeHook: () => Unit,
-      stateChangeAfterHook: () => Unit,
       host: String,
       port: Int,
       endpoint: String
@@ -98,8 +97,6 @@ private[pact4s] object StateChanger {
             .getOrElse(
               pact4sLogger.warn(s"No state change definition was provided for received state $s with parameters $ps")
             )
-          // Apply after hook
-          stateChangeAfterHook.apply()
         })
         stateChangeMaybeApplied match {
           case Failure(exception) =>

--- a/shared/src/main/scala/pact4s/StateChanger.scala
+++ b/shared/src/main/scala/pact4s/StateChanger.scala
@@ -35,8 +35,13 @@ private[pact4s] object StateChanger {
     def shutdown(): Unit = ()
   }
 
-  class SimpleServer(stateChange: PartialFunction[ProviderState, Unit], host: String, port: Int, endpoint: String)
-      extends StateChanger {
+  class SimpleServer(
+      stateChange: PartialFunction[ProviderState, Unit],
+      stateChangeBeforeHook: () => Unit,
+      host: String,
+      port: Int,
+      endpoint: String
+  ) extends StateChanger {
     private var isShutdown: Boolean    = true
     private var stopServer: () => Unit = () => ()
 
@@ -84,6 +89,9 @@ private[pact4s] object StateChanger {
         }.toOption
 
         val stateChangeMaybeApplied = Try(stateAndResponse.foreach { case (s, ps, _) =>
+          // Apply before hook
+          stateChangeBeforeHook.apply()
+          // Apply state change function
           stateChange
             .lift(ProviderState(s, ps))
             .getOrElse(


### PR DESCRIPTION
Aims to solve #368.

I've added the before hook definition as part of the existing `withStateChangeFunction` but this is debatable, maybe another dedicated `withStateChangeBeforeHook` makes more sense?

Also I was not entirely sure if we need to maintain some kind of binary compatibility, I guess not as we are in 0.x versions but my changes probably break binary compatibility.