### PR TITLE
🐛 fix(provider-verification): allow empty tags when using pending pacts

### DIFF
--- a/models/src/main/scala/pact4s/provider/ProviderInfoBuilder.scala
+++ b/models/src/main/scala/pact4s/provider/ProviderInfoBuilder.scala
@@ -31,7 +31,7 @@ import java.net.URL
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, ZoneOffset}
 import java.util.function.Consumer
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
@@ -199,7 +199,7 @@ final class ProviderInfoBuilder private (
   ): Either[Throwable, ProviderInfo] =
     pactSource match {
       case p: PactBrokerWithSelectors =>
-        p.validate() match {
+        p.validate(providerBranch) match {
           case Left(value) => Left(value)
           case Right(_) =>
             val pactJvmAuth: Auth = p.auth match {
@@ -207,6 +207,7 @@ final class ProviderInfoBuilder private (
               case Some(TokenAuth(token))      => new Auth.BearerAuthentication(token, Auth.DEFAULT_AUTH_HEADER)
               case Some(BasicAuth(user, pass)) => new Auth.BasicAuthentication(user, pass)
             }
+            @nowarn("cat=deprecation")
             val brokerOptions: PactBrokerOptions = new PactBrokerOptions(
               p.enablePending,
               p.providerTags.map(_.toList).getOrElse(Nil).asJava,

--- a/models/src/test/scala/pact4s/provider/PactBrokerWithSelectorsSpec.scala
+++ b/models/src/test/scala/pact4s/provider/PactBrokerWithSelectorsSpec.scala
@@ -5,21 +5,30 @@ import munit.FunSuite
 import pact4s.provider.PactSource.PactBrokerWithSelectors
 
 import java.time.Instant
+import scala.annotation.nowarn
 
+@nowarn
 class PactBrokerWithSelectorsSpec extends FunSuite {
-  test("pending enabled but no provider tags should throw IllegalArgumentException") {
+
+  test("pending enabled but no provider branch should throw IllegalArgumentException") {
     assert(
-      PactBrokerWithSelectors("brokerUrl").withPendingPacts(true).withOptionalProviderTags(None).validate().isLeft
+      PactBrokerWithSelectors("brokerUrl").withPendingPacts(true).validate(None).isLeft
     )
   }
 
-  test("WIP enabled but no provider tags should throw IllegalArgumentException") {
+  test("pending enabled but no provider tags nor branch should throw IllegalArgumentException") {
+    assert(
+      PactBrokerWithSelectors("brokerUrl").withPendingPacts(true).withOptionalProviderTags(None).validate(None).isLeft
+    )
+  }
+
+  test("WIP enabled but no provider tags nor branch should throw IllegalArgumentException") {
     assert(
       PactBrokerWithSelectors("brokerUrl")
         .withWipPactsSince(
           WipPactsSince.instant(Instant.now)
         )
-        .validate()
+        .validate(None)
         .isLeft
     )
   }
@@ -37,7 +46,8 @@ class PactBrokerWithSelectorsSpec extends FunSuite {
         WipPactsSince.instant(Instant.now)
       )
       .withPendingPacts(false)
-    p.validate()
+    p.validate(None)
     assertEquals(p.includeWipPactsSince, WipPactsSince.never)
   }
+
 }

--- a/shared/src/test/scala/pact4s/MockProviderServer.scala
+++ b/shared/src/test/scala/pact4s/MockProviderServer.scala
@@ -174,7 +174,7 @@ class MockProviderServer(port: Int, hasFeatureX: Boolean = false)(implicit file:
       pactSource = PactBrokerWithSelectors(
         brokerUrl = "https://test.pactflow.io"
       ).pipe(b =>
-        if (pendingPactsEnabled) b.withPendingPactsEnabled(ProviderTags("SNAPSHOT")) else b.withPendingPactsDisabled
+        if (pendingPactsEnabled) b.withPendingPactsEnabled else b.withPendingPactsDisabled
       ).withAuth(BasicAuth("dXfltyFMgNOFZAxr8io9wJ37iUpY42M", "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"))
         .withConsumerVersionSelectors(consumerVersionSelector)
     ).withPort(port)


### PR DESCRIPTION
Solves #520

Enabling pending pacts now requires to have either tags or branch set for the provider (but one of them can be undefined).

As the `providerBranch` is already set when calling `verifyPacts`, I didn't add it as a parameter to the `PactBrokerWithSelectors` class like the `providerTags` currently are. I'm not entirely sure if this matches the desired code architecture or not.

I took this opportunity to flag as deprecated all methods referring to the `providerTags` in `PactBrokerWithSelectors`.