### PR TITLE
Replace deprecated URL constructor with URI.toURL in main

### DIFF
--- a/models/src/main/scala/pact4s/provider/ProviderInfoBuilder.scala
+++ b/models/src/main/scala/pact4s/provider/ProviderInfoBuilder.scala
@@ -26,6 +26,7 @@ import pact4s.provider.PactSource.{FileSource, PactBroker, PactBrokerWithSelecto
 import pact4s.provider.StateManagement.StateManagementFunction
 import pact4s.provider.VerificationSettings.AnnotatedMethodVerificationSettings
 
+import java.net.URI
 import java.net.URL
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, ZoneOffset}
@@ -166,7 +167,7 @@ final class ProviderInfoBuilder private (
       p.setVerificationType(PactVerification.ANNOTATED_METHOD)
       p.setPackagesToScan(packagesToScan.asJava)
     }
-    stateManagement.foreach(s => p.setStateChangeUrl(new URL(s.url)))
+    stateManagement.foreach(s => p.setStateChangeUrl(new URI(s.url).toURL))
     p.setRequestFilter {
       // because java
       new Consumer[HttpRequest] {


### PR DESCRIPTION
The URL constructor used in ProviderInfoBuilder has been [deprecated as of JDK20](https://inside.java/2023/02/15/quality-heads-up/), therefore pact4s fails to build using the latest LTS JDK.

This replaces the constructor with `URI.toURL()` such that the project can be compiled using JDK versions > 20.