### PR TITLE
Add zio-test support in java8

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Mostly dependency-free wrapper of [pact-jvm](https://github.com/pact-foundation/
 
 `pact4s` is available through maven-central. 
 
-This library provides support for `munit-cats-effect`, `weaver`, and `scalatest`, to write and verify both request/response and message pacts. The underlying library, pact-jvm, is currently supported on two branches, depending on the jdk version: 
+This library provides support for `munit-cats-effect`, `weaver`, `scalatest` and `zio-test`, to write and verify both request/response and message pacts. The underlying library, pact-jvm, is currently supported on two branches, depending on the jdk version: 
 
 | Branch | Pact Spec | JDK |
 | ------ | ------------- | --- |
@@ -48,6 +48,7 @@ All the modules in `pact4s` are built against both of these branches to accommod
 "io.github.jbwheatley" %% "pact4s-munit-cats-effect" % xxx
 "io.github.jbwheatley" %% "pact4s-weaver"            % xxx
 "io.github.jbwheatley" %% "pact4s-scalatest"         % xxx
+"io.github.jbwheatley" %% "pact4s-zio-test"          % xxx
 ```
 
 We also offer some additional helpers for using JSON encoders directly in your pact definitions. Currently, support is offered for `circe` and `play-json` in the modules `pact4s-circe` and `pact4s-play-json`, respectively. If you would like to see support for your favourite scala JSON library, consider submitting a PR!
@@ -70,7 +71,7 @@ publish the pacts to files in `./example/resources/pacts` which the provider tes
 
 ## Writing Pacts
 
-The modules `pact4s-munit-cats-effect`, `pact4s-weaver` and `pact4s-scalatest` mixins all share common interfaces for defining pacts. The APIs for each of these modules is slightly different to account for the differences between the APIs of the testing frameworks. We recommend looking at the tests in this project for examples of each, or the examples module.
+The modules `pact4s-munit-cats-effect`, `pact4s-weaver`, `pact4s-scalatest` and `pact4s-zio-test` mixins all share common interfaces for defining pacts. The APIs for each of these modules is slightly different to account for the differences between the APIs of the testing frameworks. We recommend looking at the tests in this project for examples of each, or the examples module.
 
 #### Using JSON bodies
 

--- a/build.sbt
+++ b/build.sbt
@@ -116,6 +116,17 @@ lazy val weaver =
     .dependsOn(shared % "compile->compile;test->test")
     .dependsOn(circe % "test->test")
 
+lazy val zioTest =
+  (project in file("ziotest-pact"))
+    .settings(commonSettings)
+    .settings(
+      name := "pact4s-zio-test",
+      libraryDependencies ++= Dependencies.zioTest,
+      testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
+    )
+    .dependsOn(shared % "compile->compile;test->test")
+    .dependsOn(circe % "test->test")
+
 lazy val exampleConsumer =
   (project in file("example/consumer"))
     .settings(commonSettings)
@@ -144,6 +155,7 @@ lazy val pact4s = (project in file("."))
     munit,
     scalaTest,
     weaver,
+    zioTest,
     shared,
     circe,
     playJson,
@@ -157,7 +169,7 @@ lazy val deletePactFiles = taskKey[Unit]("deletes pact files created during test
 deletePactFiles := {
   import java.io.File
   import scala.reflect.io.Directory
-  List(scalaTest.base.base, munit.base.base, weaver.base.base).foreach { project =>
+  List(scalaTest.base.base, munit.base.base, weaver.base.base, zioTest.base.base).foreach { project =>
     new Directory(new File(s"./$project/target/pacts")).deleteRecursively()
     ()
   }
@@ -177,6 +189,8 @@ addCommandAlias(
     "project munit",
     "+test",
     "project weaver",
+    "+test",
+    "project zioTest",
     "+test",
     "project scalaTest",
     "+test",
@@ -208,6 +222,8 @@ addCommandAlias(
     "project munit",
     "test",
     "project weaver",
+    "test",
+    "project zioTest",
     "test",
     "project scalaTest",
     "test",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,6 +27,8 @@ object Dependencies {
 
   val _munit = "0.7.29"
 
+  val _zio = "2.0.21"
+
   val munitCatsEffect = "1.0.7"
 
   val models: Seq[ModuleID] = Seq(
@@ -60,6 +62,12 @@ object Dependencies {
   val weaver: Seq[ModuleID] = Seq(
     "com.disneystreaming" %% "weaver-core" % _weaver % Provided,
     "com.disneystreaming" %% "weaver-cats" % _weaver % Test
+  )
+
+  val zioTest: Seq[ModuleID] = Seq(
+    "dev.zio" %% "zio"          % _zio,
+    "dev.zio" %% "zio-test"     % _zio,
+    "dev.zio" %% "zio-test-sbt" % _zio
   )
 
   val circe: Seq[ModuleID] = Seq(

--- a/ziotest-pact/src/main/scala/pact4s/ziotest/MessagePactForger.scala
+++ b/ziotest-pact/src/main/scala/pact4s/ziotest/MessagePactForger.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 io.github.jbwheatley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pact4s.ziotest
+
+import au.com.dius.pact.core.model.messaging.Message
+import pact4s.MessagePactForgerResources
+import zio.test.{Spec, TestAspect, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.{Scope, UIO, ZIO}
+
+import scala.jdk.CollectionConverters._
+
+trait MessagePactForger extends ZIOSpecDefault with MessagePactForgerResources {
+
+  def specName: String = s"Pact: ${pact.getConsumer.getName} - ${pact.getProvider.getName}"
+
+  def messages: List[Message] = pact.getMessages.asScala.toList
+
+  @volatile private var testFailed = false
+
+  def verify(message: Message): Spec[Any, Nothing] = message.getDescription match {
+    case description => test(s"Missing verification for message: '$description'")(assertTrue(false))
+  }
+
+  def tests: Seq[Spec[Any, Nothing]] = messages.map(verify)
+
+  override def spec: Spec[TestEnvironment with Scope, Throwable] = suite(specName)(tests) @@ TestAspect.aroundAllWith(
+    for {
+      validationPactVersion <- ZIO.attempt(validatePactVersion(pactSpecVersion))
+      _ <- ZIO.foreachDiscard(validationPactVersion.left.toSeq)(e =>
+        ZIO.logError(s"failed to validate pact version: $e")
+      )
+    } yield validationPactVersion.isRight
+  )(validatePactVersion =>
+    if (validatePactVersion && !testFailed)
+      beforeWritePacts() *> ZIO
+        .attempt(writeMessagePactToFile())
+        .catchAll(e => ZIO.logError(s"failed to write pact file: $e"))
+    else
+      ZIO.succeed(pact4sLogger.error(notWritingPactMessage(pact))).when(testFailed)
+  ) @@ TestAspect.afterFailure(ZIO.succeed(this.testFailed = true))
+
+  override private[pact4s] type Effect[A] = ZIO[Any, Throwable, A]
+
+  override def beforeWritePacts(): UIO[Unit] = ZIO.unit
+}

--- a/ziotest-pact/src/main/scala/pact4s/ziotest/PactVerifier.scala
+++ b/ziotest-pact/src/main/scala/pact4s/ziotest/PactVerifier.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 io.github.jbwheatley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pact4s.ziotest
+
+import pact4s.PactVerifyResources
+import sourcecode.{File, FileName, Line}
+
+trait PactVerifier extends PactVerifyResources {
+  override private[pact4s] def skip(message: String)(implicit fileName: FileName, file: File, line: Line): Unit = ()
+
+  override private[pact4s] def failure(message: String)(implicit fileName: FileName, file: File, line: Line): Nothing =
+    throw new RuntimeException(message)
+
+}
+
+trait MessagePactVerifier extends PactVerifier {
+  def messages: ResponseFactory
+  override def responseFactory: Option[ResponseFactory] = Some(messages)
+}

--- a/ziotest-pact/src/main/scala/pact4s/ziotest/RequestResponsePactForger.scala
+++ b/ziotest-pact/src/main/scala/pact4s/ziotest/RequestResponsePactForger.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 io.github.jbwheatley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pact4s.ziotest
+
+import au.com.dius.pact.consumer.BaseMockServer
+import au.com.dius.pact.core.model.RequestResponseInteraction
+import pact4s.RequestResponsePactForgerResources
+import zio.test.{Spec, TestAspect, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.{Scope, UIO, ZIO, ZLayer}
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+trait RequestResponsePactForger extends ZIOSpecDefault with RequestResponsePactForgerResources {
+
+  def specName: String = s"Pact: ${pact.getConsumer.getName} - ${pact.getProvider.getName}"
+
+  private val allTestsSucceeded: AtomicBoolean = new AtomicBoolean(false)
+
+  def verify(interaction: RequestResponseInteraction): Spec[BaseMockServer, Nothing] =
+    interaction.getDescription match {
+      case description => test(s"Missing verification for message: '$description'")(assertTrue(false))
+    }
+
+  def mockServer: ZLayer[Scope, Throwable, BaseMockServer] = ZLayer.fromZIO {
+    ZIO.acquireRelease(
+      for {
+        mockServer <- ZIO.attempt(createServer)
+        _          <- ZIO.attempt(mockServer.start())
+      } yield mockServer
+    )(mockServer =>
+      for {
+        _ <- ZIO.attempt(mockServer.stop()).catchAll(e => ZIO.logError(s"failed to stop mock server: $e"))
+        _ <-
+          (beforeWritePacts() *> ZIO
+            .attempt(verifyResultAndWritePactFiles(mockServer))
+            .catchAll(e => ZIO.logError(s"failed to write pacts: $e"))).when(allTestsSucceeded.get())
+      } yield ()
+    )
+  }
+
+  def tests: Seq[Spec[BaseMockServer, Nothing]] = interactions.map(verify)
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    (suite(specName)(tests) @@ TestAspect.afterAllSuccess(ZIO.succeed(allTestsSucceeded.set(true))))
+      .provideSomeLayerShared[TestEnvironment with Scope](mockServer)
+
+  override private[pact4s] type Effect[A] = ZIO[Any, Throwable, A]
+
+  override def beforeWritePacts(): UIO[Unit] = ZIO.unit
+}

--- a/ziotest-pact/src/test/resources/logback-test.xml
+++ b/ziotest-pact/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%thread] %-5level  %logger{35} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="io.github.jbwheatley.pact4s.Pact4sLogger" level="INFO" />
+    <logger name="au.com.dius.pact.consumer" level="debug"/>
+    <logger name="au.com.dius.pact.provider" level="debug"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/ziotest-pact/src/test/scala/pact4s/ziotest/message/PactForgerSuite.scala
+++ b/ziotest-pact/src/test/scala/pact4s/ziotest/message/PactForgerSuite.scala
@@ -1,0 +1,56 @@
+package pact4s.ziotest.message
+
+import au.com.dius.pact.consumer.PactTestExecutionContext
+import au.com.dius.pact.core.model.messaging.{Message, MessagePact}
+import io.circe.Json
+import pact4s.TestModels
+import pact4s.circe.implicits.messagePactDecoder
+import pact4s.ziotest.MessagePactForger
+import zio.ZIO
+import zio.test.{Spec, ZIOSpecDefault, assertTrue}
+
+object PactForgerSuite extends ZIOSpecDefault with MessagePactForger {
+  override def pact: MessagePact = TestModels.messagePact
+  override val pactTestExecutionContext: PactTestExecutionContext = new PactTestExecutionContext(
+    "./ziotest-pact/target/pacts"
+  )
+  override val specName: String = "MessagePactForgerSuite"
+
+  override def verify(message: Message): Spec[Any, Nothing] = message.getDescription match {
+    case "A message to say hello" =>
+      test("A message to say hello should responded to with a message containing `harry`")(
+        for {
+          _ <- ZIO.unit
+          containedHello = message.as[Json].flatMap(_.hcursor.get[String]("hello"))
+          metadataHi     = message.metadata.getOrElse("hi", "")
+        } yield assertTrue(
+          containedHello.isRight && containedHello.getOrElse("").equals("harry") && metadataHi.equals("there")
+        )
+      )
+
+    case "A message to say goodbye" =>
+      test("A message to say goodbye should be responded to with a message containing `harry`")(for {
+        _ <- ZIO.unit
+        containedGoodbye = message.as[Json].flatMap(_.hcursor.get[String]("goodbye"))
+      } yield assertTrue(containedGoodbye.isRight && containedGoodbye.getOrElse("").equals("harry")))
+
+    case "A message with nested arrays in the body" =>
+      test("A message with nested Int arrays should be responded to with [1, 2, 3]")(for {
+        _ <- ZIO.unit
+        containedArray = message.as[Json].flatMap(_.hcursor.get[List[Int]]("array"))
+      } yield assertTrue(containedArray.isRight && containedArray.getOrElse(List.empty).equals(List(1, 2, 3))))
+
+    case "A message with a json array as content" =>
+      test("A message with a json array should be responded to with (1, true)")(for {
+        _ <- ZIO.unit
+        res = for {
+          json <- message.as[Json]
+          acur = json.hcursor.downArray
+          int  <- acur.get[Int]("a")
+          bool <- acur.right.get[Boolean]("b")
+        } yield (int, bool)
+      } yield assertTrue(res.isRight && res.getOrElse((0, false)).equals((1, true))))
+
+    case description => test(s"Missing verification for message: '$description'")(assertTrue(false))
+  }
+}

--- a/ziotest-pact/src/test/scala/pact4s/ziotest/message/PactVerifierBrokerSuite.scala
+++ b/ziotest-pact/src/test/scala/pact4s/ziotest/message/PactVerifierBrokerSuite.scala
@@ -1,0 +1,23 @@
+package pact4s.ziotest.message
+
+import pact4s.MockProviderServer
+import pact4s.messages.MessagesProvider
+import pact4s.provider.{ProviderInfoBuilder, PublishVerificationResults}
+import pact4s.ziotest.MessagePactVerifier
+import zio.{Scope, ZIO}
+import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+
+object PactVerifierBrokerSuite extends ZIOSpecDefault with MessagePactVerifier {
+  lazy val mock = new MockProviderServer(49156)
+
+  def messages: ResponseFactory     = MessagesProvider.messages
+  def provider: ProviderInfoBuilder = mock.brokerMessageProviderInfo
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    test("Verify pacts for provider `MessageProvider`, zio-test")(
+      ZIO
+        .attempt(
+          verifyPacts(publishVerificationResults = Some(PublishVerificationResults(providerVersion = "SNAPSHOT")))
+        )
+        .as(assertTrue(true))
+    )
+}

--- a/ziotest-pact/src/test/scala/pact4s/ziotest/message/PactVerifierFileSuite.scala
+++ b/ziotest-pact/src/test/scala/pact4s/ziotest/message/PactVerifierFileSuite.scala
@@ -1,0 +1,20 @@
+package pact4s.ziotest.message
+
+import pact4s.MockProviderServer
+import pact4s.messages.MessagesProvider
+import pact4s.provider.ProviderInfoBuilder
+import pact4s.ziotest.MessagePactVerifier
+import zio.{Scope, ZIO}
+import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+
+object PactVerifierFileSuite extends ZIOSpecDefault with MessagePactVerifier {
+  lazy val mock = new MockProviderServer(49157)
+
+  def messages: ResponseFactory     = MessagesProvider.messages
+  def provider: ProviderInfoBuilder = mock.fileSourceMessageProviderInfo
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    test("Verify pacts for provider `MessageProvider`, zio-test") {
+      ZIO.attempt(verifyPacts()).as(assertTrue(true))
+    }
+}

--- a/ziotest-pact/src/test/scala/pact4s/ziotest/requestresponse/PactForgerSuite.scala
+++ b/ziotest-pact/src/test/scala/pact4s/ziotest/requestresponse/PactForgerSuite.scala
@@ -1,0 +1,85 @@
+package pact4s.ziotest.requestresponse
+
+import au.com.dius.pact.consumer.{BaseMockServer, PactTestExecutionContext}
+import au.com.dius.pact.core.model.{RequestResponseInteraction, RequestResponsePact}
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.implicits.catsSyntaxApplicativeId
+import io.circe.Json
+import io.circe.syntax.EncoderOps
+import org.http4s._
+import org.http4s.circe._
+import org.http4s.client.Client
+import org.http4s.ember.client.EmberClientBuilder
+import org.http4s.headers.`Content-Type`
+import org.typelevel.ci.{CIString, CIStringSyntax}
+import pact4s.TestModels
+import pact4s.ziotest.RequestResponsePactForger
+import zio.ZIO
+import zio.test.{Spec, ZIOSpecDefault, assertTrue}
+
+object PactForgerSuite extends ZIOSpecDefault with RequestResponsePactForger {
+
+  val client: Client[IO] = EmberClientBuilder.default[IO].build.allocated.unsafeRunSync()._1
+
+  override def pact: RequestResponsePact = TestModels.requestResponsePact
+  override val pactTestExecutionContext: PactTestExecutionContext = new PactTestExecutionContext(
+    "./ziotest-pact/target/pacts"
+  )
+  override def specName: String = "RequestResponsePactForgerSuite"
+  override def verify(interaction: RequestResponseInteraction): Spec[BaseMockServer, Nothing] =
+    interaction.getDescription match {
+      case "a request to say Hello" =>
+        test("A request to say Hello should return a response with harry")(for {
+          mockServer <- ZIO.service[BaseMockServer]
+          request = Request[IO](
+            method = Method.POST,
+            uri = Uri.unsafeFromString(mockServer.getUrl + "/hello"),
+            headers = Headers(Header.Raw(CIString("other-header"), "howdy"))
+          )
+            .withEntity(Json.obj("name" -> "harry".asJson))
+          response = client.run(request).use(_.as[String]).unsafeRunSync()
+        } yield assertTrue(response.equals("{\"hello\":\"harry\"}")))
+
+      case "a request to say Goodbye" =>
+        test("A request to say goodbye should return HTTP status 204")(for {
+          mockServer <- ZIO.service[BaseMockServer]
+          request = Request[IO](
+            uri = Uri.unsafeFromString(mockServer.getUrl + "/goodbye"),
+            headers = Headers(`Content-Type`(MediaType.application.json))
+          )
+          response = client.run(request).use(_.status.code.pure[IO]).unsafeRunSync()
+        } yield assertTrue(response == 204))
+
+      case "a request to find a friend" =>
+        test("A request to find a friend named bob should return found")(for {
+          mockServer <- ZIO.service[BaseMockServer]
+          request = Request[IO](
+            uri = Uri.unsafeFromString(mockServer.getUrl + "/anyone-there/bob")
+          )
+          response = client.run(request).use(_.as[String]).unsafeRunSync()
+        } yield assertTrue(response.equals("{\"found\":\"bob\"}")))
+
+      case "a request to find anyone" =>
+        test("A request to find anyone should return HTTP status code 404")(for {
+          mockServer <- ZIO.service[BaseMockServer]
+          request = Request[IO](
+            uri = Uri.unsafeFromString(mockServer.getUrl + "/anyone-there")
+          )
+          response = client.run(request).use(_.status.code.pure[IO]).unsafeRunSync()
+        } yield assertTrue(response == 404))
+
+      case "a request with auth header" =>
+        test("A request to /authorized with auth header should return HTTP status code 200")(for {
+          mockServer <- ZIO.service[BaseMockServer]
+          request = Request[IO](
+            uri = Uri.unsafeFromString(mockServer.getUrl + "/authorized")
+          )
+            .putHeaders(headers.Authorization(Credentials.Token(ci"Bearer", "super-secure")))
+          response = client.run(request).use(_.status.code.pure[IO]).unsafeRunSync()
+        } yield assertTrue(response == 200))
+
+      case _ => test(s"Missing verification for interaction '${interaction.getDescription}'")(assertTrue(false))
+    }
+
+}

--- a/ziotest-pact/src/test/scala/pact4s/ziotest/requestresponse/PactVerifierBrokerFeatureBranchSuite.scala
+++ b/ziotest-pact/src/test/scala/pact4s/ziotest/requestresponse/PactVerifierBrokerFeatureBranchSuite.scala
@@ -1,0 +1,36 @@
+package pact4s.ziotest.requestresponse
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import pact4s.MockProviderServer
+import pact4s.provider.{Branch, ConsumerVersionSelectors, ProviderInfoBuilder}
+import pact4s.ziotest.PactVerifier
+import zio.{Scope, ZIO, ZLayer}
+import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+
+import scala.concurrent.duration.DurationInt
+
+object PactVerifierBrokerFeatureBranchSuite extends ZIOSpecDefault with PactVerifier {
+  val mock = new MockProviderServer(49200, hasFeatureX = true)
+
+  override val provider: ProviderInfoBuilder =
+    mock.brokerProviderInfo(consumerVersionSelector = ConsumerVersionSelectors.branch("feat/x"))
+
+  val mockLayer: ZLayer[Any with Scope, Throwable, IO[Unit]] = ZLayer.fromZIO {
+    ZIO.acquireRelease(
+      for {
+        serverStart <- ZIO.attempt(mock.server.allocated.unsafeRunSync())
+      } yield serverStart._2
+    )(shutdown =>
+      ZIO.attempt(shutdown.unsafeRunSync()).catchAll(e => ZIO.logError(s"failed to shutdown mock server: $e"))
+    )
+  }
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    test("Verify pacts for provider `Pact4sProvider` with a feature branch, zio-test")(
+      for {
+        _ <- ZIO.attempt(verifyPacts(Some(Branch("feat/x"))))
+        featureXState = mock.featureXState.get.unsafeRunTimed(10.seconds)
+      } yield assertTrue(featureXState.contains(true))
+    ).provideLayerShared(mockLayer)
+}

--- a/ziotest-pact/src/test/scala/pact4s/ziotest/requestresponse/PactVerifierBrokerMatchingBranchSuite.scala
+++ b/ziotest-pact/src/test/scala/pact4s/ziotest/requestresponse/PactVerifierBrokerMatchingBranchSuite.scala
@@ -1,0 +1,39 @@
+package pact4s.ziotest.requestresponse
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import pact4s.MockProviderServer
+import pact4s.provider.{Branch, ConsumerVersionSelectors, ProviderInfoBuilder}
+import pact4s.ziotest.PactVerifier
+import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.{Scope, ZIO, ZLayer}
+
+import scala.concurrent.duration.DurationInt
+
+object PactVerifierBrokerMatchingBranchSuite extends ZIOSpecDefault with PactVerifier {
+  val mock = new MockProviderServer(49300, hasFeatureX = true)
+
+  override val provider: ProviderInfoBuilder =
+    mock.brokerProviderInfo(
+      consumerVersionSelector = ConsumerVersionSelectors.matchingBranch,
+      pendingPactsEnabled = true
+    )
+
+  val mockLayer: ZLayer[Any with Scope, Throwable, IO[Unit]] = ZLayer.fromZIO {
+    ZIO.acquireRelease(
+      for {
+        serverStart <- ZIO.attempt(mock.server.allocated.unsafeRunSync())
+      } yield serverStart._2
+    )(shutdown =>
+      ZIO.attempt(shutdown.unsafeRunSync()).catchAll(e => ZIO.logError(s"failed to shutdown mock server: $e"))
+    )
+  }
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    test("Verify pacts for provider `Pact4sProvider` with a feature branch and matching branch selector, zio-test")(
+      for {
+        _ <- ZIO.attempt(verifyPacts(Some(Branch("feat/x"))))
+        featureXState = mock.featureXState.get.unsafeRunTimed(10.seconds)
+      } yield assertTrue(featureXState.contains(true))
+    ).provideLayerShared(mockLayer)
+}

--- a/ziotest-pact/src/test/scala/pact4s/ziotest/requestresponse/PactVerifierBrokerSuite.scala
+++ b/ziotest-pact/src/test/scala/pact4s/ziotest/requestresponse/PactVerifierBrokerSuite.scala
@@ -1,0 +1,35 @@
+package pact4s.ziotest.requestresponse
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import pact4s.MockProviderServer
+import pact4s.provider.{Branch, ConsumerVersionSelectors, ProviderInfoBuilder}
+import pact4s.ziotest.PactVerifier
+import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.{Scope, ZIO, ZLayer}
+
+object PactVerifierBrokerSuite extends ZIOSpecDefault with PactVerifier {
+  val mock = new MockProviderServer(49158)
+
+  override def provider: ProviderInfoBuilder =
+    mock.brokerProviderInfo(consumerVersionSelector = ConsumerVersionSelectors.mainBranch)
+
+  val mockLayer: ZLayer[Any with Scope, Throwable, IO[Unit]] = ZLayer.fromZIO {
+    ZIO.acquireRelease(
+      for {
+        serverStart <- ZIO.attempt(mock.server.allocated.unsafeRunSync())
+      } yield serverStart._2
+    )(shutdown =>
+      ZIO.attempt(shutdown.unsafeRunSync()).catchAll(e => ZIO.logError(s"failed to shutdown mock server: $e"))
+    )
+  }
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    test("Verify pacts for provider `Pact4sProvider`, zio-test")(
+      for {
+        _ <- ZIO.attempt(verifyPacts(Some(Branch.MAIN)))
+        featureXState = mock.featureXState.tryGet.unsafeRunSync()
+      } yield assertTrue(featureXState.isEmpty)
+    ).provideLayerShared(mockLayer)
+
+}

--- a/ziotest-pact/src/test/scala/pact4s/ziotest/requestresponse/PactVerifierStateChangeFunctionSuite.scala
+++ b/ziotest-pact/src/test/scala/pact4s/ziotest/requestresponse/PactVerifierStateChangeFunctionSuite.scala
@@ -1,0 +1,35 @@
+package pact4s.ziotest.requestresponse
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import pact4s.MockProviderServer
+import pact4s.provider.ProviderInfoBuilder
+import pact4s.ziotest.PactVerifier
+import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.{Scope, ZIO, ZLayer}
+
+object PactVerifierStateChangeFunctionSuite extends ZIOSpecDefault with PactVerifier {
+  val mock = new MockProviderServer(49171)
+
+  override val provider: ProviderInfoBuilder = mock
+    .fileSourceProviderInfo(
+      useStateChangeFunction = true,
+      stateChangePortOverride = Some(64645)
+    )
+
+  val mockLayer: ZLayer[Any with Scope, Throwable, IO[Unit]] = ZLayer.fromZIO {
+    ZIO.acquireRelease(
+      for {
+        serverStart <- ZIO.attempt(mock.server.allocated.unsafeRunSync())
+        (_, shutdown) = serverStart
+      } yield shutdown
+    )(shutdown =>
+      ZIO.attempt(shutdown.unsafeRunSync()).catchAll(e => ZIO.logError(s"failed to shutdown mock server: $e"))
+    )
+  }
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    test("Verify pacts for provider `Pact4sProvider`, zio-test") {
+      ZIO.attempt(verifyPacts()).as(assertTrue(true))
+    }.provideLayerShared(mockLayer)
+}

--- a/ziotest-pact/src/test/scala/pact4s/ziotest/requestresponse/PactVerifierSuite.scala
+++ b/ziotest-pact/src/test/scala/pact4s/ziotest/requestresponse/PactVerifierSuite.scala
@@ -1,0 +1,31 @@
+package pact4s.ziotest.requestresponse
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import pact4s.MockProviderServer
+import pact4s.provider.ProviderInfoBuilder
+import pact4s.ziotest.PactVerifier
+import zio.{Scope, ZIO, ZLayer}
+import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+
+object PactVerifierSuite extends ZIOSpecDefault with PactVerifier {
+  val mock = new MockProviderServer(49159)
+
+  override val provider: ProviderInfoBuilder = mock.fileSourceProviderInfo()
+
+  val mockLayer: ZLayer[Any with Scope, Throwable, IO[Unit]] = ZLayer.fromZIO {
+    ZIO.acquireRelease(
+      for {
+        serverStart <- ZIO.attempt(mock.server.allocated.unsafeRunSync())
+        (_, shutdown) = serverStart
+      } yield shutdown
+    )(shutdown =>
+      ZIO.attempt(shutdown.unsafeRunSync()).catchAll(e => ZIO.logError(s"failed to shutdown mock server: $e"))
+    )
+  }
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    test("Verify pacts for provider `Pact4sProvider`, zio-test") {
+      ZIO.attempt(verifyPacts()).as(assertTrue(true))
+    }.provideLayerShared(mockLayer)
+}

--- a/ziotest-pact/src/test/scala/pact4s/ziotest/requestresponse/PendingPactVerificationSuite.scala
+++ b/ziotest-pact/src/test/scala/pact4s/ziotest/requestresponse/PendingPactVerificationSuite.scala
@@ -1,0 +1,13 @@
+package pact4s.ziotest.requestresponse
+
+import pact4s.PendingPactVerificationFixture
+import pact4s.ziotest.PactVerifier
+import zio.ZIO
+import zio.test.{Spec, ZIOSpecDefault, assertTrue}
+
+object PendingPactVerificationSuite extends ZIOSpecDefault with PactVerifier with PendingPactVerificationFixture {
+  override def spec: Spec[Any, Throwable] = test("pending pact failure") {
+    ZIO.attempt(verifyPacts()).as(assertTrue(true))
+  }
+
+}


### PR DESCRIPTION
This adds support for using pact4s with [zio-test](https://zio.dev/reference/test/), the testing library of the [ZIO](https://zio.dev) framework.

This allows for using pact4s in a more idiomatic fashion in ZIO-based projects, eliminating the need for wrapping effects in other test frameworks.

(java8-equivalent of PR #529)