### PR TITLE
Fix java8 checks pr

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -5,9 +5,8 @@ on:
       - main
       - java8
   pull_request:
-    branches:
-      - main
-      - java8
+    types: [opened, edited, reopened, synchronize]
+    
 env:
   JABBA_INDEX: 'https://github.com/typelevel/jdk-index/raw/main/index.json'
 jobs:


### PR DESCRIPTION
Apply same changes as @jbwheatley did for the main branch, so that we can PR checks on the PRs coming from forks targeting java8 branch.