### PR TITLE
📦 ci: upgrade Actions versions

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -13,10 +13,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: olafurpg/setup-scala@v13
+      - uses: olafurpg/setup-scala@v14
         with:
           java-version: temurin@17
       - run: sbt commitCheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: olafurpg/setup-scala@v13
+      - uses: olafurpg/setup-scala@v14
         with:
           java-version: temurin@17
       - uses: olafurpg/setup-gpg@v3

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v40.1.2
+        uses: renovatebot/github-action@v40
         with:
           configurationFile: .github/renovate-config.js
           token: ${{ secrets.REPO_GITHUB_TOKEN }}


### PR DESCRIPTION
Following warnings raised by the CI:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2.3.4, olafurpg/setup-scala@v13, olafurpg/setup-gpg@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

There's no newer `setup-gpg` action for now and we should also [move away from `setup-scala`](https://github.com/jbwheatley/pact4s/issues/600).