### PR TITLE
ci: use setup-java action instead of setup-scala

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -16,7 +16,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: olafurpg/setup-scala@v14
+      - name: Setup Java
+        uses: actions/setup-java@v4
         with:
-          java-version: temurin@17
+          distribution: temurin
+          java-version: 17
+          cache: sbt
       - run: sbt commitCheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: olafurpg/setup-scala@v14
+      - name: Setup Java
+        uses: actions/setup-java@v4
         with:
-          java-version: temurin@17
+          distribution: temurin
+          java-version: 17
+          cache: sbt
       - uses: olafurpg/setup-gpg@v3
       - run: sbt ci-release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: sbt
-      - uses: olafurpg/setup-gpg@v3
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
Closes https://github.com/jbwheatley/pact4s/issues/600 and relates to https://github.com/jbwheatley/pact4s/pull/599