### PR TITLE
Document that port cannot be set in parallel tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Mostly dependency-free wrapper of [pact-jvm](https://github.com/pact-foundation/
       - [Using Pact Matching DSL](#using-pact-matching-dsl)
       - [Using JSON bodies](#using-json-bodies)
     + [Request/Response Pacts](#requestresponse-pacts)
-      - [Choosing a port](#choosing-a-port)
+      - [Choosing an address and/or port](#choosing-an-address-andor-port)
       - ['Inline' Style of Processing Request/Response Pacts](#inline-style-of-processing-requestresponse-pacts)
     + [Message Pacts](#message-pacts)
     + [Mixed Pacts](#mixed-pacts)
@@ -263,14 +263,18 @@ Examples:
 - [weaver](./example/consumer/src/test/scala/http/consumer/WeaverPact.scala)
 - [ziotest](./example/consumer/src/test/scala/http/consumer/ZiotestPact.scala)
 
-#### Choosing a port
+#### Choosing an address and/or port
 
-If your consumer test need that the provider mock server runs on a specific port, you can override `mockProviderConfig` from `RequestResponsePactForger` like:
+If your consumer test needs the provider mock server to run on a specific address and/or port, you can override `mockProviderConfig` from `RequestResponsePactForger` like:
 
 ```scala
-// Mock server will run on port 9003
+// Mock server will run on localhost, port 9003
 override val mockProviderConfig: MockProviderConfig = MockProviderConfig.httpConfig("localhost", 9003)
 ```
+
+Note that if you want to set a specific port, you have to disable parallel test execution, as the same port cannot be
+used by multiple parallel instances of the mock server.
+See [ZiotestInlinePactSequential](./example/consumer/src/test/scala/http/consumer/ZiotestInlinePact.scala)
 
 #### 'Inline' Style of Processing Request/Response Pacts
 

--- a/README.md
+++ b/README.md
@@ -272,10 +272,6 @@ If your consumer test needs the provider mock server to run on a specific addres
 override val mockProviderConfig: MockProviderConfig = MockProviderConfig.httpConfig("localhost", 9003)
 ```
 
-Note that if you want to set a specific port, you have to disable parallel test execution, as the same port cannot be
-used by multiple parallel instances of the mock server.
-See [ZiotestInlinePactSequential](./example/consumer/src/test/scala/http/consumer/ZiotestInlinePact.scala)
-
 #### 'Inline' Style of Processing Request/Response Pacts
 
 Instead of defining one pact for the whole test class, containing all interactions for all test cases, you may want to define for each test case only the relevant partial pact. This can be done using the trait `InlineRequestResponsePactForging` and the method `withPact` that it provides.
@@ -334,8 +330,15 @@ class TestWithInlinePactDefinitions extends AnyFunSpec with InlineRequestRespons
 }
 ```
 
-This style may be useful when it is impractical to write all interactions for all test cases in one single pact. While in this approach the `BaseMockServer` is created and started for each test case individually, it does not
+This style may be useful when it is impractical to write all interactions for all test cases in one single pact.
+While in this approach the `BaseMockServer` is created and started for each test case individually, it does not
 appear to have a noticeable performance impact.
+
+Note that if you want to set a specific port while using the "inline" style, you cannot use parallel test execution, as
+the same port cannot be used by multiple parallel instances of the mock server.
+See e.g. [WeaverInlinePactSequential](./example/consumer/src/test/scala/http/consumer/WeaverInlinePact.scala) and [ZiotestInlinePactSequential](./example/consumer/src/test/scala/http/consumer/ZiotestInlinePact.scala)
+(MUnit and ScalaTest execute tests sequentially by default).
+
 
 ### Message Pacts
 

--- a/example/consumer/src/test/scala/http/consumer/MunitPact.scala
+++ b/example/consumer/src/test/scala/http/consumer/MunitPact.scala
@@ -16,6 +16,7 @@
 
 package http.consumer
 
+import au.com.dius.pact.consumer.model.MockProviderConfig
 import au.com.dius.pact.consumer.{ConsumerPactBuilder, PactTestExecutionContext}
 import au.com.dius.pact.core.model.RequestResponsePact
 import cats.effect.IO
@@ -31,6 +32,8 @@ import pact4s.munit.RequestResponsePactForger
 
 class MunitPact extends RequestResponsePactForger with ExamplePactCommons {
   override val pactTestExecutionContext: PactTestExecutionContext = executionContext
+
+  override val mockProviderConfig: MockProviderConfig = MockProviderConfig.httpConfig("localhost", 1234)
 
   val pact: RequestResponsePact =
     ConsumerPactBuilder

--- a/example/consumer/src/test/scala/http/consumer/ScalaTestPact.scala
+++ b/example/consumer/src/test/scala/http/consumer/ScalaTestPact.scala
@@ -16,6 +16,7 @@
 
 package http.consumer
 
+import au.com.dius.pact.consumer.model.MockProviderConfig
 import au.com.dius.pact.consumer.{ConsumerPactBuilder, PactTestExecutionContext}
 import au.com.dius.pact.core.model.RequestResponsePact
 import cats.effect.IO
@@ -29,8 +30,9 @@ import pact4s.circe.implicits._
 import pact4s.scalatest.RequestResponsePactForger
 
 class ScalaTestPact extends AnyFlatSpec with Matchers with ExamplePactCommons with RequestResponsePactForger {
-
   override val pactTestExecutionContext: PactTestExecutionContext = executionContext
+
+  override val mockProviderConfig: MockProviderConfig = MockProviderConfig.httpConfig("localhost", 1234)
 
   val pact: RequestResponsePact =
     ConsumerPactBuilder

--- a/example/consumer/src/test/scala/http/consumer/WeaverInlinePact.scala
+++ b/example/consumer/src/test/scala/http/consumer/WeaverInlinePact.scala
@@ -29,7 +29,17 @@ import pact4s.circe.implicits._
 import pact4s.weaver.InlineRequestResponsePactForging
 import weaver.IOSuite
 
-object WeaverInlinePact extends IOSuite with InlineRequestResponsePactForging[IO] with ExamplePactCommons {
+object WeaverInlinePactParallel extends WeaverInlinePact {
+  override val mockProviderConfig: MockProviderConfig = MockProviderConfig.httpConfig("localhost")
+}
+
+object WeaverInlinePactSequential extends WeaverInlinePact {
+  override def maxParallelism = 1
+
+  override val mockProviderConfig: MockProviderConfig = MockProviderConfig.httpConfig("localhost", 1234)
+}
+
+abstract class WeaverInlinePact extends IOSuite with InlineRequestResponsePactForging[IO] with ExamplePactCommons {
 
   override type Res = Client[IO]
 
@@ -38,8 +48,6 @@ object WeaverInlinePact extends IOSuite with InlineRequestResponsePactForging[IO
   override val pactTestExecutionContext: PactTestExecutionContext = new PactTestExecutionContext(
     "../resources/pacts"
   )
-
-  override val mockProviderConfig: MockProviderConfig = MockProviderConfig.httpConfig("localhost")
 
   private def pact: PactDslWithProvider =
     ConsumerPactBuilder

--- a/example/consumer/src/test/scala/http/consumer/WeaverPact.scala
+++ b/example/consumer/src/test/scala/http/consumer/WeaverPact.scala
@@ -16,6 +16,7 @@
 
 package http.consumer
 
+import au.com.dius.pact.consumer.model.MockProviderConfig
 import au.com.dius.pact.consumer.{ConsumerPactBuilder, PactTestExecutionContext}
 import au.com.dius.pact.core.model.RequestResponsePact
 import cats.effect.{IO, Resource}
@@ -32,6 +33,8 @@ object WeaverPact extends IOSuite with RequestResponsePactForger[IO] with Exampl
   override val pactTestExecutionContext: PactTestExecutionContext = new PactTestExecutionContext(
     "../resources/pacts"
   )
+
+  override val mockProviderConfig: MockProviderConfig = MockProviderConfig.httpConfig("localhost", 1234)
 
   override type Resources = Client[IO]
 

--- a/example/consumer/src/test/scala/http/consumer/ZiotestInlinePact.scala
+++ b/example/consumer/src/test/scala/http/consumer/ZiotestInlinePact.scala
@@ -27,16 +27,24 @@ import org.http4s.{BasicCredentials, Uri}
 import pact4s.circe.implicits._
 import pact4s.ziotest.InlineRequestResponsePactForging
 import zio.interop.catz._
-import zio.test.{Spec, TestEnvironment, assertTrue}
+import zio.test.{Spec, TestAspect, TestEnvironment, assertTrue}
 import zio.{Scope, Task, ZIO, ZLayer}
 
 import scala.annotation.nowarn
 
-object ZiotestInlinePact extends InlineRequestResponsePactForging with ExamplePactCommons {
+object ZiotestInlinePactParallel extends ZiotestInlinePact {
+  override val mockProviderConfig: MockProviderConfig = MockProviderConfig.httpConfig("localhost")
+}
+
+object ZiotestInlinePactSequential extends ZiotestInlinePact {
+  override val mockProviderConfig: MockProviderConfig = MockProviderConfig.httpConfig("localhost", 1234)
+
+  override def spec: Spec[TestEnvironment with Scope, Any] = super.spec @@ TestAspect.sequential
+}
+
+abstract class ZiotestInlinePact extends InlineRequestResponsePactForging with ExamplePactCommons {
 
   override val pactTestExecutionContext: PactTestExecutionContext = executionContext
-
-  override val mockProviderConfig: MockProviderConfig = MockProviderConfig.httpConfig("localhost")
 
   private def pact: PactDslWithProvider =
     ConsumerPactBuilder

--- a/example/consumer/src/test/scala/http/consumer/ZiotestPact.scala
+++ b/example/consumer/src/test/scala/http/consumer/ZiotestPact.scala
@@ -16,6 +16,7 @@
 
 package http.consumer
 
+import au.com.dius.pact.consumer.model.MockProviderConfig
 import au.com.dius.pact.consumer.{BaseMockServer, ConsumerPactBuilder, PactTestExecutionContext}
 import au.com.dius.pact.core.model.RequestResponsePact
 import io.circe.Json
@@ -33,6 +34,8 @@ import scala.annotation.nowarn
 
 object ZiotestPact extends RequestResponsePactForgerWith[Client[Task]] with ExamplePactCommons {
   override val pactTestExecutionContext: PactTestExecutionContext = executionContext
+
+  override val mockProviderConfig: MockProviderConfig = MockProviderConfig.httpConfig("localhost", 1234)
 
   val pact: RequestResponsePact =
     ConsumerPactBuilder


### PR DESCRIPTION
Hi,

as noted in #726, overriding the port does not (always) work with ZIO or Weaver. The reason seems to be that both execute tests in parallel by default.

I documented this in the README and added two specific tests for ZIO.

For Weaver, setting the suite to sequential did not work/help. I tried it as documented here: https://disneystreaming.github.io/weaver-test/docs/parallelism

(BTW, #726 was not my first contribution as mentioned in the release notes for 0.15.1. #526 was my first :) )

Best,
Daniel