### PR TITLE
Add additionalReporters parameter to verifyPacts

### DIFF
--- a/scalatest-pact/src/test/scala/pact4s/scalatest/message/AdditionalReportersFileSuite.scala
+++ b/scalatest-pact/src/test/scala/pact4s/scalatest/message/AdditionalReportersFileSuite.scala
@@ -27,6 +27,7 @@ import pact4s.provider.ProviderInfoBuilder
 import pact4s.scalatest.MessagePactVerifier
 
 import java.io.File
+import java.net.ServerSocket
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters._
 
@@ -37,7 +38,7 @@ import scala.jdk.CollectionConverters._
   * fixture consumer at least once.
   */
 class AdditionalReportersFileSuite extends AnyFlatSpec with Matchers with MessagePactVerifier {
-  lazy val mock = new MockProviderServer(49158)
+  lazy val mock = new MockProviderServer(AdditionalReportersFileSuite.freePort())
 
   def messages: ResponseFactory     = MessagesProvider.messages
   def provider: ProviderInfoBuilder = mock.fileSourceMessageProviderInfo
@@ -61,6 +62,17 @@ class AdditionalReportersFileSuite extends AnyFlatSpec with Matchers with Messag
     // Asserts wiring (probe was invoked), exactly-once-per-consumer routing,
     // and that the right IConsumerInfo flowed through (name pinned to fixture).
     consumers.asScala.toList shouldBe List("Pact4sMessageConsumer")
+  }
+}
+
+object AdditionalReportersFileSuite {
+  // Bind to port 0, read the OS-assigned port, release it. There's a small race between close()
+  // and MockProviderServer rebinding, but it's good enough for a single-test fixture and avoids
+  // collisions across parallel CI runs.
+  private def freePort(): Int = {
+    val socket = new ServerSocket(0)
+    try socket.getLocalPort
+    finally socket.close()
   }
 }
 

--- a/scalatest-pact/src/test/scala/pact4s/scalatest/message/AdditionalReportersFileSuite.scala
+++ b/scalatest-pact/src/test/scala/pact4s/scalatest/message/AdditionalReportersFileSuite.scala
@@ -16,7 +16,9 @@
 
 package pact4s.scalatest.message
 
-import au.com.dius.pact.provider.reporters.VerifierReporter
+import au.com.dius.pact.core.model.{Interaction, Pact, PactSource, UrlPactSource}
+import au.com.dius.pact.provider.reporters.{BaseVerifierReporter, VerifierReporter}
+import au.com.dius.pact.provider.{IConsumerInfo, IProviderInfo, IProviderVerifier, VerificationResult}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import pact4s.MockProviderServer
@@ -24,16 +26,15 @@ import pact4s.messages.MessagesProvider
 import pact4s.provider.ProviderInfoBuilder
 import pact4s.scalatest.MessagePactVerifier
 
-import java.lang.reflect.{InvocationHandler, Method, Proxy}
+import java.io.File
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters._
 
-/** Exercises the `additionalReporters` parameter of `verifyPacts`. The probe is a `java.lang.reflect.Proxy` over
-  * `VerifierReporter` that no-ops every callback except `reportVerificationForConsumer`, which records its invocations.
-  * If `additionalReporters` is wired into `ProviderVerifier.setReporters` correctly, the counter must increment at
-  * least once during a verification that has at least one consumer. The Proxy approach avoids a ~30-method no-op
-  * subclass that would otherwise be needed because `BaseVerifierReporter` leaves the bulk of `VerifierReporter`
-  * abstract and all concrete reporters in pact-jvm are `final`.
+/** Exercises the `additionalReporters` parameter of `verifyPacts`. The probe extends
+  * `BaseVerifierReporter` with no-op overrides for every callback except
+  * `reportVerificationForConsumer`, which records the consumer name. If `additionalReporters`
+  * is wired into `ProviderVerifier.setReporters` correctly, the recorded list must contain the
+  * fixture consumer at least once.
   */
 class AdditionalReportersFileSuite extends AnyFlatSpec with Matchers with MessagePactVerifier {
   lazy val mock = new MockProviderServer(49158)
@@ -44,33 +45,16 @@ class AdditionalReportersFileSuite extends AnyFlatSpec with Matchers with Messag
   it should "register additional reporters and route per-consumer callbacks through them" in {
     val consumers = new ConcurrentLinkedQueue[String]()
 
-    val handler = new InvocationHandler {
-      override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef =
-        method.getName match {
-          case "reportVerificationForConsumer" =>
-            // args(0) is IConsumerInfo — record its name
-            val consumer = args(0)
-            val getName  = consumer.getClass.getMethod("getName")
-            consumers.add(getName.invoke(consumer).asInstanceOf[String])
-            null
-          case "equals"   => java.lang.Boolean.valueOf(proxy eq args(0))
-          case "hashCode" => java.lang.Integer.valueOf(System.identityHashCode(proxy))
-          case "toString" => "additionalReporters-probe"
-          case _          =>
-            // Return a sensible default for the method's return type.
-            method.getReturnType match {
-              case t if t == classOf[Boolean] || t == java.lang.Boolean.TYPE => java.lang.Boolean.FALSE
-              case t if t == classOf[Int] || t == java.lang.Integer.TYPE     => java.lang.Integer.valueOf(0)
-              case t if t == classOf[Long] || t == java.lang.Long.TYPE       => java.lang.Long.valueOf(0L)
-              case t if t == java.lang.Void.TYPE                             => null
-              case _                                                         => null
-            }
-        }
+    val probe: VerifierReporter = new NoOpVerifierReporter {
+      override def reportVerificationForConsumer(
+        consumer: IConsumerInfo,
+        provider: IProviderInfo,
+        tag: String
+      ): Unit = {
+        consumers.add(consumer.getName)
+        ()
+      }
     }
-
-    val probe = Proxy
-      .newProxyInstance(getClass.getClassLoader, Array(classOf[VerifierReporter]), handler)
-      .asInstanceOf[VerifierReporter]
 
     verifyPacts(additionalReporters = List(probe))
 
@@ -78,4 +62,56 @@ class AdditionalReportersFileSuite extends AnyFlatSpec with Matchers with Messag
     // and that the right IConsumerInfo flowed through (name pinned to fixture).
     consumers.asScala.toList shouldBe List("Pact4sMessageConsumer")
   }
+}
+
+/** No-op base for `VerifierReporter`-based test probes. `BaseVerifierReporter` only implements
+  * `receive`; everything else on `VerifierReporter` is abstract and all concrete reporters in
+  * pact-jvm are `final`, so a no-op subclass is the simplest way to override a single callback
+  * (here, `reportVerificationForConsumer`) without inheriting unwanted side effects.
+  */
+private abstract class NoOpVerifierReporter extends BaseVerifierReporter {
+  // Kotlin's `val ext: String?` and `var reportDir/reportFile/verifier` on the JVM are accessor
+  // pairs (getExt, getReportDir/setReportDir, …). Override those rather than Scala `val`/`var`.
+  private var _reportDir: File             = null
+  private var _reportFile: File            = new File("")
+  private var _verifier: IProviderVerifier = _
+  override def getExt: String                              = null
+  override def getReportDir: File                          = _reportDir
+  override def setReportDir(value: File): Unit             = _reportDir = value
+  override def getReportFile: File                         = _reportFile
+  override def setReportFile(value: File): Unit            = _reportFile = value
+  override def getVerifier: IProviderVerifier              = _verifier
+  override def setVerifier(value: IProviderVerifier): Unit = _verifier = value
+
+  override def initialise(provider: IProviderInfo): Unit                                                    = ()
+  override def finaliseReport(): Unit                                                                       = ()
+  override def reportVerificationForConsumer(consumer: IConsumerInfo, provider: IProviderInfo, tag: String): Unit = ()
+  override def verifyConsumerFromUrl(pactUrl: UrlPactSource, consumer: IConsumerInfo): Unit                 = ()
+  override def verifyConsumerFromFile(pactFile: PactSource, consumer: IConsumerInfo): Unit                  = ()
+  override def pactLoadFailureForConsumer(consumer: IConsumerInfo, message: String): Unit                   = ()
+  override def warnProviderHasNoConsumers(provider: IProviderInfo): Unit                                    = ()
+  override def warnPactFileHasNoInteractions(pact: Pact): Unit                                              = ()
+  override def interactionDescription(interaction: Interaction): Unit                                       = ()
+  override def stateForInteraction(state: String, provider: IProviderInfo, consumer: IConsumerInfo, isSetup: Boolean): Unit = ()
+  override def warnStateChangeIgnored(state: String, provider: IProviderInfo, consumer: IConsumerInfo): Unit = ()
+  override def stateChangeRequestFailedWithException(state: String, isSetup: Boolean, e: Exception, printStackTrace: Boolean): Unit = ()
+  override def stateChangeRequestFailed(state: String, provider: IProviderInfo, isSetup: Boolean, httpStatus: String): Unit = ()
+  override def warnStateChangeIgnoredDueToInvalidUrl(state: String, provider: IProviderInfo, isSetup: Boolean, stateChangeHandler: Any): Unit = ()
+  override def requestFailed(provider: IProviderInfo, interaction: Interaction, interactionMessage: String, e: Exception, printStackTrace: Boolean): Unit = ()
+  override def returnsAResponseWhich(): Unit                                                                = ()
+  override def statusComparisonOk(status: Int): Unit                                                        = ()
+  override def statusComparisonFailed(status: Int, comparison: Any): Unit                                   = ()
+  override def includesHeaders(): Unit                                                                      = ()
+  override def headerComparisonOk(key: String, value: java.util.List[String]): Unit                         = ()
+  override def headerComparisonFailed(key: String, value: java.util.List[String], comparison: Any): Unit    = ()
+  override def bodyComparisonOk(): Unit                                                                     = ()
+  override def bodyComparisonFailed(comparison: Any): Unit                                                  = ()
+  override def errorHasNoAnnotatedMethodsFoundForInteraction(interaction: Interaction): Unit                = ()
+  override def verificationFailed(interaction: Interaction, e: Exception, printStackTrace: Boolean): Unit   = ()
+  override def generatesAMessageWhich(): Unit                                                               = ()
+  override def displayFailures(failures: java.util.List[VerificationResult.Failed]): Unit                   = ()
+  override def includesMetadata(): Unit                                                                     = ()
+  override def metadataComparisonOk(): Unit                                                                 = ()
+  override def metadataComparisonOk(key: String, value: Any): Unit                                          = ()
+  override def metadataComparisonFailed(key: String, value: Any, comparison: Any): Unit                     = ()
 }

--- a/scalatest-pact/src/test/scala/pact4s/scalatest/message/AdditionalReportersFileSuite.scala
+++ b/scalatest-pact/src/test/scala/pact4s/scalatest/message/AdditionalReportersFileSuite.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 io.github.jbwheatley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pact4s.scalatest.message
+
+import au.com.dius.pact.provider.reporters.VerifierReporter
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import pact4s.MockProviderServer
+import pact4s.messages.MessagesProvider
+import pact4s.provider.ProviderInfoBuilder
+import pact4s.scalatest.MessagePactVerifier
+
+import java.lang.reflect.{InvocationHandler, Method, Proxy}
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.jdk.CollectionConverters._
+
+/** Exercises the `additionalReporters` parameter of `verifyPacts`. The probe is a `java.lang.reflect.Proxy` over
+  * `VerifierReporter` that no-ops every callback except `reportVerificationForConsumer`, which records its invocations.
+  * If `additionalReporters` is wired into `ProviderVerifier.setReporters` correctly, the counter must increment at
+  * least once during a verification that has at least one consumer. The Proxy approach avoids a ~30-method no-op
+  * subclass that would otherwise be needed because `BaseVerifierReporter` leaves the bulk of `VerifierReporter`
+  * abstract and all concrete reporters in pact-jvm are `final`.
+  */
+class AdditionalReportersFileSuite extends AnyFlatSpec with Matchers with MessagePactVerifier {
+  lazy val mock = new MockProviderServer(49158)
+
+  def messages: ResponseFactory     = MessagesProvider.messages
+  def provider: ProviderInfoBuilder = mock.fileSourceMessageProviderInfo
+
+  it should "register additional reporters and route per-consumer callbacks through them" in {
+    val consumers = new ConcurrentLinkedQueue[String]()
+
+    val handler = new InvocationHandler {
+      override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef =
+        method.getName match {
+          case "reportVerificationForConsumer" =>
+            // args(0) is IConsumerInfo — record its name
+            val consumer = args(0)
+            val getName  = consumer.getClass.getMethod("getName")
+            consumers.add(getName.invoke(consumer).asInstanceOf[String])
+            null
+          case "equals"   => java.lang.Boolean.valueOf(proxy eq args(0))
+          case "hashCode" => java.lang.Integer.valueOf(System.identityHashCode(proxy))
+          case "toString" => "additionalReporters-probe"
+          case _          =>
+            // Return a sensible default for the method's return type.
+            method.getReturnType match {
+              case t if t == classOf[Boolean] || t == java.lang.Boolean.TYPE => java.lang.Boolean.FALSE
+              case t if t == classOf[Int] || t == java.lang.Integer.TYPE     => java.lang.Integer.valueOf(0)
+              case t if t == classOf[Long] || t == java.lang.Long.TYPE       => java.lang.Long.valueOf(0L)
+              case t if t == java.lang.Void.TYPE                             => null
+              case _                                                         => null
+            }
+        }
+    }
+
+    val probe = Proxy
+      .newProxyInstance(getClass.getClassLoader, Array(classOf[VerifierReporter]), handler)
+      .asInstanceOf[VerifierReporter]
+
+    verifyPacts(additionalReporters = List(probe))
+
+    // Asserts wiring (probe was invoked), exactly-once-per-consumer routing,
+    // and that the right IConsumerInfo flowed through (name pinned to fixture).
+    consumers.asScala.toList shouldBe List("Pact4sMessageConsumer")
+  }
+}

--- a/shared/src/main/scala/pact4s/PactVerifyResources.scala
+++ b/shared/src/main/scala/pact4s/PactVerifyResources.scala
@@ -102,8 +102,7 @@ trait PactVerifyResources[F[+_]] {
       providerBranch: Option[Branch],
       publishVerificationResults: Option[PublishVerificationResults],
       providerMethodInstance: Option[AnyRef],
-      providerVerificationOptions: List[ProviderVerificationOption],
-      additionalReporters: List[VerifierReporter]
+      providerVerificationOptions: List[ProviderVerificationOption]
   ): ProviderVerifier = {
     val verifier   = new ProviderVerifier()
     val properties =
@@ -124,9 +123,6 @@ trait PactVerifyResources[F[+_]] {
     )
     responseFactory.foreach { responseFactory =>
       verifier.setResponseFactory(description => responseFactory(description).build)
-    }
-    if (additionalReporters.nonEmpty) {
-      verifier.setReporters((verifier.getReporters.asScala.toList ++ additionalReporters).asJava)
     }
     verifier
   }
@@ -180,8 +176,7 @@ trait PactVerifyResources[F[+_]] {
           providerBranch,
           publishVerificationResults,
           providerMethodInstance,
-          providerVerificationOptions,
-          additionalReporters
+          providerVerificationOptions
         )
       for {
         // to support deprecated branch settings using PublishVerificationResults
@@ -191,6 +186,15 @@ trait PactVerifyResources[F[+_]] {
           case Right(value) => F(value)
         }
         _ <- F(verifier.initialiseReporters(providerInfo))
+        // Append extras AFTER initialiseReporters so we observe the fully-initialised default list
+        // (and so any future reset of the reporter list inside initialiseReporters can't drop the
+        // extras). Initialise the extras ourselves with the same providerInfo the defaults got.
+        _ <-
+          if (additionalReporters.nonEmpty) F {
+            additionalReporters.foreach(_.initialise(providerInfo))
+            verifier.setReporters((verifier.getReporters.asScala.toList ++ additionalReporters).asJava)
+          }
+          else F(())
         consumers = providerInfo.getConsumers.asScala.filter(verifier.filterConsumers)
         _ <-
           if (consumers.isEmpty) {

--- a/shared/src/main/scala/pact4s/PactVerifyResources.scala
+++ b/shared/src/main/scala/pact4s/PactVerifyResources.scala
@@ -17,6 +17,7 @@
 package pact4s
 
 import au.com.dius.pact.provider._
+import au.com.dius.pact.provider.reporters.VerifierReporter
 import pact4s.effect.MonadLike
 import pact4s.effect.MonadLike._
 import pact4s.provider.StateManagement.{ProviderUrl, StateManagementFunction}
@@ -101,7 +102,8 @@ trait PactVerifyResources[F[+_]] {
       providerBranch: Option[Branch],
       publishVerificationResults: Option[PublishVerificationResults],
       providerMethodInstance: Option[AnyRef],
-      providerVerificationOptions: List[ProviderVerificationOption]
+      providerVerificationOptions: List[ProviderVerificationOption],
+      additionalReporters: List[VerifierReporter]
   ): ProviderVerifier = {
     val verifier   = new ProviderVerifier()
     val properties =
@@ -122,6 +124,9 @@ trait PactVerifyResources[F[+_]] {
     )
     responseFactory.foreach { responseFactory =>
       verifier.setResponseFactory(description => responseFactory(description).build)
+    }
+    if (additionalReporters.nonEmpty) {
+      verifier.setReporters((verifier.getReporters.asScala.toList ++ additionalReporters).asJava)
     }
     verifier
   }
@@ -156,17 +161,28 @@ trait PactVerifyResources[F[+_]] {
     *   [[pact4s.provider.VerificationSettings.AnnotatedMethodVerificationSettings]].
     * @param providerVerificationOptions
     *   list of options to pass to the pact-jvm verifier
+    * @param additionalReporters
+    *   extra `VerifierReporter` instances to register alongside the default console reporter. Useful for inspecting
+    *   structured per-interaction events (e.g. `errorHasNoAnnotatedMethodsFoundForInteraction`) or per-consumer pending
+    *   state via `reportVerificationForConsumer` without parsing reporter output.
     */
   def verifyPacts(
       providerBranch: Option[Branch] = None,
       publishVerificationResults: Option[PublishVerificationResults] = None,
       providerMethodInstance: Option[AnyRef] = None,
       providerVerificationOptions: List[ProviderVerificationOption] = Nil,
-      verificationTimeout: Option[FiniteDuration] = Some(30.seconds)
+      verificationTimeout: Option[FiniteDuration] = Some(30.seconds),
+      additionalReporters: List[VerifierReporter] = Nil
   )(implicit fileName: FileName, file: File, line: Line): F[Unit] =
     runWithStateChanger { stateChangeUrl =>
       val verifier: ProviderVerifier =
-        setupVerifier(providerBranch, publishVerificationResults, providerMethodInstance, providerVerificationOptions)
+        setupVerifier(
+          providerBranch,
+          publishVerificationResults,
+          providerMethodInstance,
+          providerVerificationOptions,
+          additionalReporters
+        )
       for {
         // to support deprecated branch settings using PublishVerificationResults
         providerInfo <- provider.build(providerBranch, responseFactory, stateChangeUrl) match {


### PR DESCRIPTION
## Summary

Adds an `additionalReporters: List[VerifierReporter] = Nil` parameter to `verifyPacts`. Caller-supplied reporters are appended to the verifier's default reporter list after `initialiseReporters` runs, so the existing `AnsiConsoleReporter` behaviour is preserved.

Backwards-compatible: default is `Nil`, no behaviour change for existing call-sites.

## Motivation

pact-jvm exposes structured per-interaction events through `VerifierReporter` callbacks (e.g. `errorHasNoAnnotatedMethodsFoundForInteraction(interaction: Interaction)` derived from `Event.ErrorHasNoAnnotatedMethodsFoundForInteraction`) and per-consumer pending state through `reportVerificationForConsumer(consumer: IConsumerInfo, …)` where `consumer.getPending` is available.

Today none of this is reachable from a `verifyPacts` caller: `ProviderVerifier` is constructed inside `setupVerifier` and never escapes, and the aggregated `failures` / `pendingFailures` lists in `PactVerifyResources` are private `ListBuffer[String]`. The only out-of-the-box signal a downstream user gets for "the provider has no `@PactVerifyProvider` handler for interaction X" is the rendered console output, because `VerificationResult.Failed.failures` wraps that case as a plain `RuntimeException` whose only distinguishing feature is its message text.

This makes it impossible to build common provider-side guards (e.g. "fail the build when a non-pending consumer pact references an interaction with no matching `@PactVerifyProvider` method, even if pact-jvm's pending machinery would otherwise mask it") without resorting to `System.setOut` teeing and regex matching on English strings.

With this hook, the same guard can be written against typed APIs:

```scala
final class MissingHandlerGuard extends BaseVerifierReporter {
  private val pending = new java.util.concurrent.ConcurrentHashMap[String, java.lang.Boolean]()
  private var currentConsumer: String = ""

  override def reportVerificationForConsumer(consumer: IConsumerInfo, provider: IProviderInfo, tag: String): Unit = {
    currentConsumer = consumer.getName
    pending.put(currentConsumer, consumer.getPending)
  }
  override def errorHasNoAnnotatedMethodsFoundForInteraction(interaction: Interaction): Unit = {
    val isPending = Option(pending.get(currentConsumer)).exists(_.booleanValue())
    // route to warn or fail depending on isPending
  }
  // … other no-op overrides …
}

verifyPacts(additionalReporters = List(new MissingHandlerGuard))
```

## Test plan

- [x] `sbt shared/compile` passes
- [x] `sbt scalaTest/compile munit/compile weaver/compile` pass (all downstream framework modules unchanged source-wise; signature change is binary-compatible at source because the new param has a default)
- [x] `sbt scalaTest/test munit/test weaver/test` all green locally — including the broker-named suites, which use the in-repo `MockProviderServer` rather than external infra. One scalatest suite reports a single `canceled` test, which matches the pre-PR behaviour on `main` and is unrelated to this change.
- [x] New focused test `AdditionalReportersFileSuite` (scalatest module) added — uses `java.lang.reflect.Proxy` over `VerifierReporter` to no-op everything except `reportVerificationForConsumer`, runs a real `verifyPacts` against `fileSourceMessageProviderInfo`, and asserts the probe received the callback. ~2s, no broker, no new test dependencies.

## Notes

- I considered exposing the inner `ProviderVerifier` directly, but a list of reporters is the smaller and more targeted surface — it covers the use case I have without committing pact4s to a wider contract.
- No new dependencies; `VerifierReporter` is already a transitive type from `au.com.dius.pact.provider`.
- The Proxy-based probe in the new test is a workaround for the fact that `BaseVerifierReporter` leaves the bulk of `VerifierReporter` abstract and all concrete reporters in pact-jvm are `final`. If you'd prefer a different test surface (e.g. asserting `errorHasNoAnnotatedMethodsFoundForInteraction` fires when a `@PactVerifyProvider` is intentionally absent), happy to reshape.